### PR TITLE
Fix translated taxonomy tag links

### DIFF
--- a/themes/cone-scroll/templates/blog-page.html
+++ b/themes/cone-scroll/templates/blog-page.html
@@ -40,7 +40,7 @@
 
 <p class="tags-data">
   {% if page.taxonomies.tags %} {% for tag in page.taxonomies.tags %}
-  <a href="{{ get_taxonomy_url(kind='tags', name=tag, lang=link_lang) }}">&#47;{{ tag }}&#47;</a>
+  <a href="{{ get_taxonomy_url(kind='tags', name=tag, lang=current_lang) }}">&#47;{{ tag }}&#47;</a>
   {% endfor %} {% endif %}
 </p>
 

--- a/themes/cone-scroll/templates/page.html
+++ b/themes/cone-scroll/templates/page.html
@@ -13,7 +13,7 @@
 
 <p class="tags-data">
   {% if page.taxonomies.tags %} {% for tag in page.taxonomies.tags %}
-  <a href="{{ get_taxonomy_url(kind='tags', name=tag, lang=link_lang) }}">&#47;{{ tag }}&#47;</a>
+  <a href="{{ get_taxonomy_url(kind='tags', name=tag, lang=current_lang) }}">&#47;{{ tag }}&#47;</a>
   {% endfor %} {% endif %}
 </p>
 </article>


### PR DESCRIPTION
## Summary
- Render page tag taxonomy links using the current page language instead of always using the default language.
- Apply the same fix to blog pages and generic pages.

## Root cause
GitHub Actions run 27188945111 failed in `Build Zola site (main site)` because translated pages had translated tag names, while `get_taxonomy_url` was forced to look those tags up in the default `zh-Hans` taxonomy. Zola treats missing taxonomy terms as fatal by default.

## Verification
- `nix-shell --run 'node scripts/zola-i18n.ts build --output-dir ./final-output'` passed: generated 244 translated pages and built 491 pages.\n- Tried the downstream Czon build with `shell.nix` providing `OPENAI_API_KEY`; it reached OpenAI calls but failed externally with rate limiting, then account balance insufficient. No Czon-generated files are included in this PR.