### PR TITLE
Pass OpenAI API key to Czon build

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -43,7 +43,13 @@ jobs:
         run: node scripts/zola-i18n.ts build --output-dir ./final-output
 
       - name: Build Czon site (sub-path /czon)
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
+          if [ -z "$OPENAI_API_KEY" ]; then
+            echo "::error::OPENAI_API_KEY secret is not configured"
+            exit 1
+          fi
           npx czon@latest build --lang zh-Hans --lang en-US --lang ja-JP --lang es-ES --lang de-DE
           mkdir -p ./final-output/czon
           cp -r ./.czon/dist/* ./final-output/czon/


### PR DESCRIPTION
## Summary
- Pass `secrets.OPENAI_API_KEY` into the Czon build step as `OPENAI_API_KEY`.
- Add a clear preflight error when the repository secret is not configured.

## Root cause
After PR #4 fixed the original Zola taxonomy failure, the next master run passed `Build Zola site (main site)` and failed in `Build Czon site (sub-path /czon)` because `npx czon@latest build` could not see `OPENAI_API_KEY` in the GitHub Actions environment. Secrets are not automatically exported to shell steps.

## Verification
- `nix --extra-experimental-features 'nix-command flakes' shell nixpkgs#actionlint -c actionlint .github/workflows/pages.yaml` passed.\n- Confirmed local `shell.nix` sets `OPENAI_API_KEY`; local full Czon build cannot be used as pass/fail evidence because the account hit external API limit/balance errors.