### PR TITLE
Configure Czon OpenAI-compatible endpoint

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -45,6 +45,9 @@ jobs:
       - name: Build Czon site (sub-path /czon)
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_BASE_URL: https://api.siliconflow.cn/v1
+          OPENAI_MODEL: Pro/deepseek-ai/DeepSeek-V3.2
+          OPENAI_MAX_TOKENS: "8192"
         run: |
           if [ -z "$OPENAI_API_KEY" ]; then
             echo "::error::OPENAI_API_KEY secret is not configured"


### PR DESCRIPTION
## Summary
- Add the same OpenAI-compatible endpoint configuration used by `shell.nix` to the Czon GitHub Actions step.
- Keep `OPENAI_API_KEY` sourced from the GitHub secret.

## Root cause
After PR #5 exported `OPENAI_API_KEY`, the rerun reached Czon but called the default OpenAI endpoint. The configured key is for the SiliconFlow-compatible endpoint used locally by `shell.nix`, so the default endpoint returned `invalid_api_key`.

## Verification
- `nix --extra-experimental-features 'nix-command flakes' shell nixpkgs#actionlint -c actionlint .github/workflows/pages.yaml` passed.