### PR TITLE
Implement daily archive TOC navigation

### DIFF
--- a/.legion/tasks/daily-log-toc-implementation/docs/pr-body.md
+++ b/.legion/tasks/daily-log-toc-implementation/docs/pr-body.md
@@ -1,0 +1,15 @@
+## Summary
+
+- Replace the daily archive select picker with a document-style date TOC.
+- Add grouped TOC data for diary and Gcores archives, including same-day sequence entries.
+- Keep the existing static paginator and infinite-loading enhancement.
+
+## Validation
+
+- `git diff --check`
+- `nix-shell --run 'zola build'`
+- Playwright screenshots for `/gcores-talks/`, `/diary/2020/`, and `/diary/2026/` at `393x852`, `1440x900`, and `2560x1440`
+
+## Notes
+
+- `scripts/split-daily-logs.mjs` was updated for future regeneration, but the full script cannot be run in this worktree because `scripts/daily-sources/*` is absent.

--- a/.legion/tasks/daily-log-toc-implementation/docs/report-walkthrough.md
+++ b/.legion/tasks/daily-log-toc-implementation/docs/report-walkthrough.md
@@ -1,0 +1,30 @@
+# Report Walkthrough: Daily Log TOC Implementation
+
+Mode: implementation
+
+## What Changed
+
+- Replaced the daily archive date picker with a document-style date TOC.
+- Reused the existing `.page-outline` visual language for the archive rail.
+- Added `data/daily-toc.json` so the template can render grouped dates without doing grouping logic in Tera.
+- Updated `scripts/split-daily-logs.mjs` so future full regenerations emit the same TOC data.
+- Removed the unused select-jump JavaScript binding while keeping the existing infinite-list enhancement.
+
+## User-Facing Behavior
+
+- Diary archives show month groups with date links.
+- Gcores archives show year groups, and duplicate dates render as one date with `01`, `02`, etc.
+- Mobile users get the date TOC in normal document flow before the feed.
+- Desktop users get a sticky left rail with a thin divider.
+- Every entry remains a plain link and pagination still works without JavaScript.
+
+## Evidence
+
+- Build and viewport evidence: `docs/test-report.md`
+- Review decision: `docs/review-change.md`
+- Design source: `.legion/tasks/daily-log-split-design/docs/rfc.md`
+
+## Residual Risk
+
+- Gcores has a long mobile TOC. This is acceptable for direct date access, but year collapse or a local filter may be worth adding if real usage feels heavy.
+- The split script update could not be executed end-to-end because `scripts/daily-sources/*` is absent in this worktree. The committed TOC data was generated from the existing `daily-index.json` and validated through Zola build.

--- a/.legion/tasks/daily-log-toc-implementation/docs/review-change.md
+++ b/.legion/tasks/daily-log-toc-implementation/docs/review-change.md
@@ -1,0 +1,53 @@
+# Review Change: Daily Log TOC Implementation
+
+## Decision
+
+PASS
+
+## Scope Review
+
+In scope:
+
+- Replaced the select-based daily archive jump UI in `daily-archive.html`.
+- Added document-outline style archive navigation using existing `.page-outline` visual language.
+- Added generated `data/daily-toc.json` and updated `scripts/split-daily-logs.mjs` to emit the same data in future full regenerations.
+- Kept existing infinite loading and static paginator fallback.
+- Added CSS only for daily archive surfaces.
+- Added Legion task docs and verification evidence.
+
+No out-of-scope production content migration or global redesign was introduced.
+
+## Correctness Review
+
+No blocking findings.
+
+Evidence:
+
+- `zola build` passes.
+- Rendered HTML no longer contains the daily archive `<select>`.
+- `gcores-talks` duplicate date `2025-07-23` renders as one date node with `01` and `02` entry links.
+- `diary/2020`, `diary/2026`, and `gcores-talks` were visually checked at mobile, 13-inch, and 27-inch viewports.
+
+## Maintainability Review
+
+No blocking findings.
+
+The TOC grouping is prepared as data instead of being inferred in the Tera template. That keeps the template mostly presentational and makes future regeneration deterministic.
+
+## Accessibility And Fallback Review
+
+No blocking findings.
+
+- Date access is plain anchor navigation.
+- The TOC uses native `<details>` / `<summary>`.
+- Existing pagination remains visible and usable without JavaScript.
+- Infinite loading remains progressive enhancement.
+
+## Security Review
+
+No security trigger was introduced. The change does not touch auth, permissions, sessions, secrets, signing, user-controlled privileged paths, or data exposure boundaries.
+
+## Non-Blocking Notes
+
+- The full Gcores TOC is long on mobile. This is acceptable for static-first date access, but future work could add year collapse or a small local filter if real use feels heavy.
+- The split script still depends on absent `scripts/daily-sources/*` files in this worktree, so the script update was validated indirectly through equivalent generated data and the final Zola build.

--- a/.legion/tasks/daily-log-toc-implementation/docs/test-report.md
+++ b/.legion/tasks/daily-log-toc-implementation/docs/test-report.md
@@ -1,0 +1,62 @@
+# Test Report: Daily Log TOC Implementation
+
+## Summary
+
+Status: PASS
+
+The production daily archive pages now render a document-style date TOC instead of a select-based date picker. Static entry links work without JavaScript, and the existing infinite-list enhancement still has a normal paginator fallback.
+
+## Commands
+
+- `git diff --check`
+- `nix-shell --run 'zola build'`
+- `nix-shell --run 'zola serve --interface 127.0.0.1 --port 1111'`
+- `rg -n "日期目录|daily-outline|<select|2025-07-23|daily-outline-seq|继续加载" public/diary/2026/index.html public/diary/2020/index.html public/gcores-talks/index.html`
+- `playwright screenshot --browser chromium --viewport-size 393,852 --wait-for-selector .daily-outline ...`
+- `playwright screenshot --browser chromium --viewport-size 1440,900 --wait-for-selector .daily-outline ...`
+- `playwright screenshot --browser chromium --viewport-size 2560,1440 --wait-for-selector .daily-outline ...`
+
+## Build Evidence
+
+`zola build` completed successfully with Zola 0.21.0 from `shell.nix`.
+
+Output summary:
+
+- Created 257 pages and 9 sections.
+- Internal anchor check completed.
+- No build errors.
+
+## Static HTML Checks
+
+Rendered production HTML confirms:
+
+- No `<select>` remains on daily archive pages.
+- `日期目录` and `.daily-outline` render on `diary/2026`, `diary/2020`, and `gcores-talks`.
+- Existing `继续加载` pagination link remains for progressive infinite loading.
+- Gcores duplicate date `2025-07-23` renders as a date node with `01` and `02` sequence links.
+
+## Viewport Matrix
+
+Temporary screenshots were generated for each page at each required size and visually inspected:
+
+| Page | 393x852 mobile | 1440x900 13-inch | 2560x1440 27-inch |
+| --- | --- | --- | --- |
+| `/gcores-talks/` | PASS | PASS | PASS |
+| `/diary/2020/` | PASS | PASS | PASS |
+| `/diary/2026/` | PASS | PASS | PASS |
+
+Findings:
+
+- Mobile: the TOC appears in-flow before the feed, matching document outline behavior and keeping specific dates reachable as plain links.
+- 13-inch: the date TOC appears as a left rail with a thin divider, and feed content remains readable without overlap.
+- 27-inch: the archive remains centered and bounded; the left rail does not stretch into a wide empty layout.
+- Gcores: duplicate same-day entries are grouped under a single date with sequence labels.
+
+## Computer Use
+
+Computer Use was loaded and used to inspect the active Zen browser state. The active browser was on an unrelated page, so no business controls were operated. Visual validation of the local implementation was performed through Playwright-rendered browser screenshots against `http://127.0.0.1:1111`.
+
+## Residual Risk
+
+- The full Gcores TOC is long on mobile. This is acceptable for the current static-first design because it prioritizes direct date access, but a future enhancement could add a small in-TOC filter or year collapse if it feels too long in real use.
+- `scripts/split-daily-logs.mjs` cannot be fully re-run in this worktree because `scripts/daily-sources/*` is absent. The new `data/daily-toc.json` was generated mechanically from existing `data/daily-index.json`, and the script was updated so future full regenerations also emit the TOC data.

--- a/.legion/tasks/daily-log-toc-implementation/log.md
+++ b/.legion/tasks/daily-log-toc-implementation/log.md
@@ -1,0 +1,12 @@
+# Daily Log TOC Implementation Log
+
+## 2026-06-10
+
+- User approved the combined recommendation: use the normal document TOC style as the base, and handle same-day multiple entries as grouped sequence links rather than a select control.
+- Loaded Legion workflow constraints. The previous `daily-log-split-design` task is design-only and complete, so this implementation uses a new task id: `daily-log-toc-implementation`.
+- Created implementation worktree at `.worktrees/daily-log-toc-implementation` from `origin/master` on branch `legion/daily-log-toc-implementation`.
+- Scope is intentionally limited to production archive navigation and styling, plus the minimum data/template support needed for duplicate same-day labels.
+- Implemented a daily archive TOC using the existing `.page-outline` visual language. Removed the select-based date jump from the template and deleted the related JavaScript binding.
+- Added `data/daily-toc.json`, derived from `data/daily-index.json`, and updated `scripts/split-daily-logs.mjs` so future full regenerations emit the same grouped TOC structure.
+- Ran `zola build` with Zola 0.21.0 through `shell.nix`; build passed.
+- Started local Zola server at `http://127.0.0.1:1111` and captured Playwright screenshots for `gcores-talks`, `diary/2020`, and `diary/2026` at 393x852, 1440x900, and 2560x1440.

--- a/.legion/tasks/daily-log-toc-implementation/plan.md
+++ b/.legion/tasks/daily-log-toc-implementation/plan.md
@@ -1,0 +1,73 @@
+# Daily Log TOC Implementation
+
+## Task Contract
+
+- **name**: Daily log TOC browsing implementation
+- **taskId**: `daily-log-toc-implementation`
+- **goal**: Replace the awkward daily archive date picker with a document-TOC style browsing surface for split daily-log archive pages, preserving the current terminal-paper visual system and keeping static navigation functional without JavaScript.
+- **problem**: The current archive jump UI reads like a form control rather than a document outline. It is especially awkward for mobile readers and cannot represent same-day multiple Gcores entries cleanly. The approved direction is to use the normal page-outline language as the base, with duplicate same-day entries represented as grouped sequence items.
+
+## Acceptance
+
+1. Implement a production archive TOC that uses the approved A+C design: document-style date outline as the base, with same-day sequence handling for multi-entry sources.
+2. Remove or replace the current `select`-based date jump surface on daily archive pages.
+3. Keep every archive entry reachable as a plain link without JavaScript; progressive infinite loading may remain a future enhancement unless existing infrastructure supports it cleanly.
+4. Preserve the existing site visual identity: paper background, mono typography, thin rules, bracketed links, no cards, no gradients, no pill controls.
+5. Support mobile, 13-inch laptop, and 27-inch desktop layouts without text overlap or layout overflow.
+6. Build the site successfully and capture responsive/browser evidence in task docs.
+7. Record implementation, verification, review, walkthrough, and wiki updates under Legion.
+
+## Scope
+
+- `themes/cone-scroll/templates/daily-archive.html`
+- `themes/cone-scroll/static/css/style.css`
+- Any existing archive data preparation code required to expose grouped date/sequence metadata to the template.
+- Task docs under `.legion/tasks/daily-log-toc-implementation/**`
+- Reusable notes under `.legion/wiki/**`
+
+## Non-goals
+
+- Do not split all legacy Markdown content in this task.
+- Do not redesign the global theme or page layout outside archive TOC needs.
+- Do not introduce a JavaScript-only archive or client-rendered app.
+- Do not add broad infinite-scroll infrastructure unless it is already present and can be wired safely within scope.
+- Do not change archive routes or entry content unless required for stable anchors.
+
+## Assumptions
+
+- The previous `daily-log-split-design` RFC remains the design source for static-first browsing.
+- The user approved the combined recommendation: A as the base TOC style, C for duplicate same-day Gcores entries.
+- Daily diary entries are date-unique within a year, while Gcores-like sources may contain multiple entries with the same date.
+- Zola remains the static site generator and current template/context shape should be preserved where possible.
+
+## Constraints
+
+- The implementation branch is developed in `.worktrees/daily-log-toc-implementation` from `origin/master`.
+- The UI must stay close to the existing `.page-outline` and article list style.
+- Links and controls must remain usable when JavaScript is disabled.
+- Mobile output must not rely on fixed-width controls.
+
+## Risks
+
+- Template context may not expose enough metadata to distinguish duplicate same-day entries without adjusting the generator.
+- Static archive pages may be paginated, so TOC scope needs to match the entries currently rendered on the page unless broader index data is already available.
+- Over-styling the TOC could drift away from the site’s existing document style.
+- Browser verification may depend on local Zola/Nix availability.
+
+## Design Summary
+
+Use one archive navigation component:
+
+- Desktop: sticky left document rail with thin right divider, visually aligned with the existing page outline.
+- Mobile: in-flow outline before the feed, using native `<details>` so it can collapse without JavaScript.
+- Date grouping: month groups for normal diary pages; duplicate-date sources render the date once with sequence entries below it.
+- Entry links: every TOC item points to a real entry anchor or entry permalink. Same-day duplicates get stable sequence labels such as `01`, `02`.
+- Infinite scroll: keep the static paginator/next link as the reliable base. The TOC implementation must not block future progressive enhancement.
+
+## Phases
+
+1. Contract: materialize this implementation task and restore design sources.
+2. Engineer: inspect current template/data/CSS, then implement the TOC component and styling.
+3. Verify: build and inspect relevant pages at mobile, 13-inch, and 27-inch viewport sizes.
+4. Review: check scope, accessibility, fallback, and design consistency.
+5. Close: write walkthrough, wiki notes, commit, rebase, push, and open/update PR.

--- a/.legion/tasks/daily-log-toc-implementation/tasks.md
+++ b/.legion/tasks/daily-log-toc-implementation/tasks.md
@@ -1,0 +1,50 @@
+# Daily Log TOC Implementation Tasks
+
+## Quick Restore
+
+- **Current phase**: Closing
+- **Current task**: Commit and prepare PR
+- **Progress**: 25/27 planned checks complete
+
+## Phase 1: Contract
+
+- [x] Load `legion-workflow`, `brainstorm`, `git-worktree-pr`, `legion-docs`, `impeccable`, and `engineer`
+- [x] Create implementation worktree from `origin/master`
+- [x] Write implementation `plan.md`
+- [x] Write implementation `tasks.md`
+- [x] Write implementation `log.md`
+- [x] Re-read contract docs before engineering
+
+## Phase 2: Engineer
+
+- [x] Read prior design RFC and approved dummy direction
+- [x] Inspect daily archive template, CSS, and data source
+- [x] Implement TOC-style archive navigation
+- [x] Implement duplicate same-day sequence display when data contains duplicates
+- [x] Remove the current select-style date picker from production pages
+- [x] Run the smallest useful local build/check
+
+## Phase 3: Verify
+
+- [x] Run production build
+- [x] Verify diary 2026 page
+- [x] Verify diary 2020 page
+- [x] Verify Gcores page
+- [x] Capture mobile, 13-inch, and 27-inch viewport evidence
+- [x] Write `docs/test-report.md`
+
+## Phase 4: Review
+
+- [x] Load `review-change`
+- [x] Review implementation against contract, design source, and fallback requirements
+- [x] Record `docs/review-change.md`
+
+## Phase 5: Closing
+
+- [x] Load `report-walkthrough`
+- [x] Write `docs/report-walkthrough.md`
+- [x] Load `legion-wiki`
+- [x] Update `.legion/wiki`
+- [ ] Commit changes
+- [ ] Rebase on `origin/master`, push branch, and open/update PR
+- [ ] Follow required checks and record final PR state or blocker

--- a/.legion/wiki/index.md
+++ b/.legion/wiki/index.md
@@ -3,9 +3,10 @@
 ## Current Durable Notes
 
 - `tasks/daily-log-split-design.md`: Daily log split architecture and viewport validation decisions.
+- `tasks/daily-log-toc-implementation.md`: Daily archive TOC implementation and duplicate-date sequence rule.
 - `patterns.md`: Reusable theme and archive implementation conventions.
 - `maintenance.md`: Follow-up implementation backlog.
 
 ## Current Truth
 
-The blog is a Zola static archive with a deliberate terminal-paper visual language. Long daily-log pages should be split into atomic Markdown pages through static sections and pagination, with infinite loading used only as progressive enhancement.
+The blog is a Zola static archive with a deliberate terminal-paper visual language. Long daily-log pages should be split into atomic Markdown pages through static sections and pagination. Daily archive navigation should look like a document TOC, with infinite loading used only as progressive enhancement.

--- a/.legion/wiki/log.md
+++ b/.legion/wiki/log.md
@@ -3,3 +3,8 @@
 ## 2026-06-08
 - Initialized wiki index, patterns, and task summary for `const-cloudflare-access`.
 - Promoted reusable patterns for Nix/czon site verification and Cloudflare Access Terraform path protection.
+
+## 2026-06-10
+- Added task summary for `daily-log-toc-implementation`.
+- Promoted the daily archive TOC pattern: document-outline navigation, plain date links, duplicate-date sequence labels, static pagination preserved.
+- Updated daily-log maintenance backlog after TOC implementation.

--- a/.legion/wiki/maintenance.md
+++ b/.legion/wiki/maintenance.md
@@ -2,11 +2,9 @@
 
 ## Daily Log Split Follow-ups
 
-- Implement `diary-2020` split first with a dry-run manifest.
-- Add a daily-entry template reusing the existing article shell.
-- Add year/source archive templates with normal Zola pagination.
+- Restore or document `scripts/daily-sources/*` so `scripts/split-daily-logs.mjs` can be re-run end-to-end from a clean worktree.
 - Keep `/diary/diary-2020/`, `/diary/diary-2026/`, and `/gcores-talks/` as compatibility surfaces during the first migration release.
 - Extend `scripts/get-gcores-talk.ts` to emit atomic files with stable source ids or deterministic date sequence suffixes.
 - Decide whether atomic daily entries should appear in the global Atom feed.
 - Decide whether Giscus comments belong on every daily entry or only on aggregate/year pages.
-- Add progressive infinite loading only after static pagination is verified.
+- Watch Gcores mobile TOC length in real use; add year collapse or a local in-TOC filter only if the direct date list feels too heavy.

--- a/.legion/wiki/patterns.md
+++ b/.legion/wiki/patterns.md
@@ -22,6 +22,16 @@ Infinite loading is a progressive enhancement over real pagination:
 - announce appended content with a polite live region
 - stop cleanly when there is no next page
 
+## Daily Archive TOC
+
+For daily archive navigation, prefer document-outline navigation over form controls:
+
+- use the existing `.page-outline` visual language
+- render dates as plain links, not select options
+- group duplicate-date sources under the date with stable sequence labels
+- keep mobile access in normal document flow with native `<details>`
+- keep desktop access as a sticky left rail with a thin divider
+
 ## Terminal-Paper UI Preservation
 
 Theme changes should keep the current blog identity:

--- a/.legion/wiki/tasks/daily-log-toc-implementation.md
+++ b/.legion/wiki/tasks/daily-log-toc-implementation.md
@@ -1,0 +1,34 @@
+# Task Note: Daily Log TOC Implementation
+
+## Status
+
+Implemented and reviewed on 2026-06-10.
+
+## Decision
+
+Daily archive navigation should use the same visual language as a normal document TOC, not a form-style date picker.
+
+Effective rule:
+
+- Use a sticky left rail on desktop.
+- Use an in-flow `<details>` outline on mobile.
+- Keep all dates as plain links.
+- Preserve static pagination and use infinite loading only as enhancement.
+
+## Duplicate-Date Rule
+
+For sources that can contain multiple entries on the same date, group entries under the date and render deterministic sequence labels:
+
+```text
+2025-07-23
+  01 topic
+  02 topic
+```
+
+The committed implementation uses `data/daily-toc.json` to represent this grouping and renders sequence labels in `themes/cone-scroll/templates/daily-archive.html`.
+
+## Evidence
+
+- Implementation report: `.legion/tasks/daily-log-toc-implementation/docs/report-walkthrough.md`
+- Test report: `.legion/tasks/daily-log-toc-implementation/docs/test-report.md`
+- Review: `.legion/tasks/daily-log-toc-implementation/docs/review-change.md`

--- a/data/daily-toc.json
+++ b/data/daily-toc.json
@@ -1,0 +1,2596 @@
+{
+  "diary-2020": [
+    {
+      "label": "2020-07",
+      "dates": [
+        {
+          "label": "07-22",
+          "date": "2020-07-22",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-07-22/",
+              "title": "2020-07-22",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "07-13",
+          "date": "2020-07-13",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-07-13/",
+              "title": "2020-07-13",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "07-10",
+          "date": "2020-07-10",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-07-10/",
+              "title": "2020-07-10",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "07-09",
+          "date": "2020-07-09",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-07-09/",
+              "title": "2020-07-09",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "07-07",
+          "date": "2020-07-07",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-07-07/",
+              "title": "2020-07-07",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "07-06",
+          "date": "2020-07-06",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-07-06/",
+              "title": "2020-07-06",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "07-02",
+          "date": "2020-07-02",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-07-02/",
+              "title": "2020-07-02",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "07-01",
+          "date": "2020-07-01",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-07-01/",
+              "title": "2020-07-01",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "2020-06",
+      "dates": [
+        {
+          "label": "06-30",
+          "date": "2020-06-30",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-06-30/",
+              "title": "2020-06-30",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "06-29",
+          "date": "2020-06-29",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-06-29/",
+              "title": "2020-06-29",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "06-28",
+          "date": "2020-06-28",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-06-28/",
+              "title": "2020-06-28",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "06-24",
+          "date": "2020-06-24",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-06-24/",
+              "title": "2020-06-24",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "06-23",
+          "date": "2020-06-23",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-06-23/",
+              "title": "2020-06-23",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "06-22",
+          "date": "2020-06-22",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-06-22/",
+              "title": "2020-06-22",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "06-19",
+          "date": "2020-06-19",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-06-19/",
+              "title": "2020-06-19",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "06-18",
+          "date": "2020-06-18",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-06-18/",
+              "title": "2020-06-18",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "06-17",
+          "date": "2020-06-17",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-06-17/",
+              "title": "2020-06-17",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "06-16",
+          "date": "2020-06-16",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-06-16/",
+              "title": "2020-06-16",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "06-15",
+          "date": "2020-06-15",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-06-15/",
+              "title": "2020-06-15",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "06-13",
+          "date": "2020-06-13",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-06-13/",
+              "title": "2020-06-13",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "06-12",
+          "date": "2020-06-12",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-06-12/",
+              "title": "2020-06-12",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "06-11",
+          "date": "2020-06-11",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-06-11/",
+              "title": "2020-06-11",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "06-10",
+          "date": "2020-06-10",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-06-10/",
+              "title": "2020-06-10",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "06-09",
+          "date": "2020-06-09",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-06-09/",
+              "title": "2020-06-09",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "06-08",
+          "date": "2020-06-08",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-06-08/",
+              "title": "2020-06-08",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "06-05",
+          "date": "2020-06-05",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-06-05/",
+              "title": "2020-06-05",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "06-04",
+          "date": "2020-06-04",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-06-04/",
+              "title": "2020-06-04",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "06-03",
+          "date": "2020-06-03",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-06-03/",
+              "title": "2020-06-03",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "06-02",
+          "date": "2020-06-02",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-06-02/",
+              "title": "2020-06-02",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "06-01",
+          "date": "2020-06-01",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-06-01/",
+              "title": "2020-06-01",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "2020-05",
+      "dates": [
+        {
+          "label": "05-29",
+          "date": "2020-05-29",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-05-29/",
+              "title": "2020-05-29",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "05-28",
+          "date": "2020-05-28",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-05-28/",
+              "title": "2020-05-28",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "05-27",
+          "date": "2020-05-27",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-05-27/",
+              "title": "2020-05-27",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "05-26",
+          "date": "2020-05-26",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-05-26/",
+              "title": "2020-05-26",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "05-25",
+          "date": "2020-05-25",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-05-25/",
+              "title": "2020-05-25",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "05-22",
+          "date": "2020-05-22",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-05-22/",
+              "title": "2020-05-22",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "05-21",
+          "date": "2020-05-21",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-05-21/",
+              "title": "2020-05-21",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "05-20",
+          "date": "2020-05-20",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-05-20/",
+              "title": "2020-05-20",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "05-19",
+          "date": "2020-05-19",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-05-19/",
+              "title": "2020-05-19",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "05-18",
+          "date": "2020-05-18",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-05-18/",
+              "title": "2020-05-18",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "05-15",
+          "date": "2020-05-15",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-05-15/",
+              "title": "2020-05-15",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "05-14",
+          "date": "2020-05-14",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-05-14/",
+              "title": "2020-05-14",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "05-13",
+          "date": "2020-05-13",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-05-13/",
+              "title": "2020-05-13",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "05-12",
+          "date": "2020-05-12",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-05-12/",
+              "title": "2020-05-12",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "05-11",
+          "date": "2020-05-11",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-05-11/",
+              "title": "2020-05-11",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "05-09",
+          "date": "2020-05-09",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-05-09/",
+              "title": "2020-05-09",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "05-08",
+          "date": "2020-05-08",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-05-08/",
+              "title": "2020-05-08",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "05-06",
+          "date": "2020-05-06",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-05-06/",
+              "title": "2020-05-06",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "2020-04",
+      "dates": [
+        {
+          "label": "04-29",
+          "date": "2020-04-29",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-04-29/",
+              "title": "2020-04-29",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "04-28",
+          "date": "2020-04-28",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-04-28/",
+              "title": "2020-04-28",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "04-27",
+          "date": "2020-04-27",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-04-27/",
+              "title": "2020-04-27",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "04-23",
+          "date": "2020-04-23",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-04-23/",
+              "title": "2020-04-23",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "04-22",
+          "date": "2020-04-22",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-04-22/",
+              "title": "2020-04-22",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "04-21",
+          "date": "2020-04-21",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-04-21/",
+              "title": "2020-04-21",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "04-20",
+          "date": "2020-04-20",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-04-20/",
+              "title": "2020-04-20",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "04-18",
+          "date": "2020-04-18",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-04-18/",
+              "title": "2020-04-18",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "04-17",
+          "date": "2020-04-17",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-04-17/",
+              "title": "2020-04-17",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "04-16",
+          "date": "2020-04-16",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-04-16/",
+              "title": "2020-04-16",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "04-15",
+          "date": "2020-04-15",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-04-15/",
+              "title": "2020-04-15",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "04-14",
+          "date": "2020-04-14",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-04-14/",
+              "title": "2020-04-14",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "04-13",
+          "date": "2020-04-13",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2020/2020-04-13/",
+              "title": "2020-04-13",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "diary-2026": [
+    {
+      "label": "2026-04",
+      "dates": [
+        {
+          "label": "04-23",
+          "date": "2026-04-23",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2026/2026-04-23/",
+              "title": "2026-04-23",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "2026-03",
+      "dates": [
+        {
+          "label": "03-24",
+          "date": "2026-03-24",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2026/2026-03-24/",
+              "title": "2026-03-24",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "03-17",
+          "date": "2026-03-17",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2026/2026-03-17/",
+              "title": "2026-03-17",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "2026-02",
+      "dates": [
+        {
+          "label": "02-05",
+          "date": "2026-02-05",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2026/2026-02-05/",
+              "title": "2026-02-05",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "02-02",
+          "date": "2026-02-02",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2026/2026-02-02/",
+              "title": "2026-02-02",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "02-01",
+          "date": "2026-02-01",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2026/2026-02-01/",
+              "title": "2026-02-01",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "2026-01",
+      "dates": [
+        {
+          "label": "01-31",
+          "date": "2026-01-31",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2026/2026-01-31/",
+              "title": "2026-01-31",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "01-27",
+          "date": "2026-01-27",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2026/2026-01-27/",
+              "title": "2026-01-27",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "01-26",
+          "date": "2026-01-26",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2026/2026-01-26/",
+              "title": "2026-01-26",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "01-25",
+          "date": "2026-01-25",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2026/2026-01-25/",
+              "title": "2026-01-25",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "01-24",
+          "date": "2026-01-24",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2026/2026-01-24/",
+              "title": "2026-01-24",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "01-23",
+          "date": "2026-01-23",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2026/2026-01-23/",
+              "title": "2026-01-23",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "01-22",
+          "date": "2026-01-22",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/diary/2026/2026-01-22/",
+              "title": "2026-01-22",
+              "topic": "",
+              "sequence_label": ""
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "gcores": [
+    {
+      "label": "2026",
+      "dates": [
+        {
+          "label": "2026-01-01",
+          "date": "2026-01-01",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2026-01-01/",
+              "title": "2026-01-01",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "2025",
+      "dates": [
+        {
+          "label": "2025-12-22",
+          "date": "2025-12-22",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2025-12-22/",
+              "title": "2025-12-22",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2025-12-08",
+          "date": "2025-12-08",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2025-12-08/",
+              "title": "2025-12-08",
+              "topic": "🍺都在酒里",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2025-11-06",
+          "date": "2025-11-06",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2025-11-06/",
+              "title": "2025-11-06",
+              "topic": "💓情感妙妙屋",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2025-10-06",
+          "date": "2025-10-06",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2025-10-06/",
+              "title": "2025-10-06",
+              "topic": "🍂秋日的第一抹色彩",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2025-09-21",
+          "date": "2025-09-21",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2025-09-21/",
+              "title": "2025-09-21",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2025-09-15",
+          "date": "2025-09-15",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2025-09-15/",
+              "title": "2025-09-15",
+              "topic": "🛡️DOTA2赛事讨论",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2025-09-14",
+          "date": "2025-09-14",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2025-09-14/",
+              "title": "2025-09-14",
+              "topic": "🛡️DOTA2赛事讨论",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2025-09-13",
+          "date": "2025-09-13",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2025-09-13/",
+              "title": "2025-09-13",
+              "topic": "🛡️DOTA2赛事讨论",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2025-09-12",
+          "date": "2025-09-12",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2025-09-12/",
+              "title": "2025-09-12",
+              "topic": "🛡️DOTA2赛事讨论",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2025-07-23",
+          "date": "2025-07-23",
+          "duplicate_count": 2,
+          "entries": [
+            {
+              "path": "/gcores-talks/2025-07-23-01/",
+              "title": "2025-07-23 #1",
+              "topic": "🧳出去走走",
+              "sequence_label": "01"
+            },
+            {
+              "path": "/gcores-talks/2025-07-23-02/",
+              "title": "2025-07-23 #2",
+              "topic": "🌙emo树洞",
+              "sequence_label": "02"
+            }
+          ]
+        },
+        {
+          "label": "2025-07-20",
+          "date": "2025-07-20",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2025-07-20/",
+              "title": "2025-07-20",
+              "topic": "💓情感妙妙屋",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2025-07-09",
+          "date": "2025-07-09",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2025-07-09/",
+              "title": "2025-07-09",
+              "topic": "🤔发癫发狂！癫火之王！",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2025-06-27",
+          "date": "2025-06-27",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2025-06-27/",
+              "title": "2025-06-27",
+              "topic": "🐒黑神话 悟空",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2025-06-21",
+          "date": "2025-06-21",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2025-06-21/",
+              "title": "2025-06-21",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2025-06-01",
+          "date": "2025-06-01",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2025-06-01/",
+              "title": "2025-06-01",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2025-05-11",
+          "date": "2025-05-11",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2025-05-11/",
+              "title": "2025-05-11",
+              "topic": "🎁BOOOM游玩感想反馈站",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2025-03-16",
+          "date": "2025-03-16",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2025-03-16/",
+              "title": "2025-03-16",
+              "topic": "🧩碎片故事",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2025-03-04",
+          "date": "2025-03-04",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2025-03-04/",
+              "title": "2025-03-04",
+              "topic": "🪄《怪物猎人 荒野》捏脸征集",
+              "sequence_label": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "2024",
+      "dates": [
+        {
+          "label": "2024-12-22",
+          "date": "2024-12-22",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-12-22/",
+              "title": "2024-12-22",
+              "topic": "🧩碎片故事",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-12-18",
+          "date": "2024-12-18",
+          "duplicate_count": 2,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-12-18-01/",
+              "title": "2024-12-18 #1",
+              "topic": "🧩碎片故事",
+              "sequence_label": "01"
+            },
+            {
+              "path": "/gcores-talks/2024-12-18-02/",
+              "title": "2024-12-18 #2",
+              "topic": "✝️赛博告解室",
+              "sequence_label": "02"
+            }
+          ]
+        },
+        {
+          "label": "2024-12-02",
+          "date": "2024-12-02",
+          "duplicate_count": 2,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-12-02-01/",
+              "title": "2024-12-02 #1",
+              "topic": "✝️赛博告解室",
+              "sequence_label": "01"
+            },
+            {
+              "path": "/gcores-talks/2024-12-02-02/",
+              "title": "2024-12-02 #2",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": "02"
+            }
+          ]
+        },
+        {
+          "label": "2024-12-01",
+          "date": "2024-12-01",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-12-01/",
+              "title": "2024-12-01",
+              "topic": "✝️赛博告解室",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-11-28",
+          "date": "2024-11-28",
+          "duplicate_count": 2,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-11-28-01/",
+              "title": "2024-11-28 #1",
+              "topic": "💎机核宝藏内容推荐",
+              "sequence_label": "01"
+            },
+            {
+              "path": "/gcores-talks/2024-11-28-02/",
+              "title": "2024-11-28 #2",
+              "topic": "🎲跑团逸闻录",
+              "sequence_label": "02"
+            }
+          ]
+        },
+        {
+          "label": "2024-11-19",
+          "date": "2024-11-19",
+          "duplicate_count": 2,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-11-19-01/",
+              "title": "2024-11-19 #1",
+              "topic": "🧩碎片故事",
+              "sequence_label": "01"
+            },
+            {
+              "path": "/gcores-talks/2024-11-19-02/",
+              "title": "2024-11-19 #2",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": "02"
+            }
+          ]
+        },
+        {
+          "label": "2024-09-29",
+          "date": "2024-09-29",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-09-29/",
+              "title": "2024-09-29",
+              "topic": "🧳出去走走",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-09-27",
+          "date": "2024-09-27",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-09-27/",
+              "title": "2024-09-27",
+              "topic": "🧳出去走走",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-09-17",
+          "date": "2024-09-17",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-09-17/",
+              "title": "2024-09-17",
+              "topic": "🧳出去走走",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-09-06",
+          "date": "2024-09-06",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-09-06/",
+              "title": "2024-09-06",
+              "topic": "🧳出去走走",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-08-28",
+          "date": "2024-08-28",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-08-28/",
+              "title": "2024-08-28",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-08-20",
+          "date": "2024-08-20",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-08-20/",
+              "title": "2024-08-20",
+              "topic": "⚙吉考斯工业",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-08-18",
+          "date": "2024-08-18",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-08-18/",
+              "title": "2024-08-18",
+              "topic": "✝️赛博告解室",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-08-05",
+          "date": "2024-08-05",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-08-05/",
+              "title": "2024-08-05",
+              "topic": "🤔发癫发狂！癫火之王！",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-07-28",
+          "date": "2024-07-28",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-07-28/",
+              "title": "2024-07-28",
+              "topic": "🚶🏻旷野漫步者",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-07-22",
+          "date": "2024-07-22",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-07-22/",
+              "title": "2024-07-22",
+              "topic": "🎵这周听了啥",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-07-20",
+          "date": "2024-07-20",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-07-20/",
+              "title": "2024-07-20",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-07-13",
+          "date": "2024-07-13",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-07-13/",
+              "title": "2024-07-13",
+              "topic": "🎦观影杂感",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-07-10",
+          "date": "2024-07-10",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-07-10/",
+              "title": "2024-07-10",
+              "topic": "🎮关于这个游戏的感受",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-07-07",
+          "date": "2024-07-07",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-07-07/",
+              "title": "2024-07-07",
+              "topic": "♟️来点儿桌游",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-07-06",
+          "date": "2024-07-06",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-07-06/",
+              "title": "2024-07-06",
+              "topic": "🎮关于这个游戏的感受",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-06-29",
+          "date": "2024-06-29",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-06-29/",
+              "title": "2024-06-29",
+              "topic": "🥨褪色者游记",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-06-08",
+          "date": "2024-06-08",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-06-08/",
+              "title": "2024-06-08",
+              "topic": "🔖这段太精彩了",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-06-06",
+          "date": "2024-06-06",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-06-06/",
+              "title": "2024-06-06",
+              "topic": "✨游戏高光时刻",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-05-29",
+          "date": "2024-05-29",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-05-29/",
+              "title": "2024-05-29",
+              "topic": "🧑🏻‍🦼虚拟主播",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-05-28",
+          "date": "2024-05-28",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-05-28/",
+              "title": "2024-05-28",
+              "topic": "🧑🏻‍🦼虚拟主播",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-05-21",
+          "date": "2024-05-21",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-05-21/",
+              "title": "2024-05-21",
+              "topic": "💥核聚变",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-05-07",
+          "date": "2024-05-07",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-05-07/",
+              "title": "2024-05-07",
+              "topic": "🧑🏻‍💻开发日志",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-03-22",
+          "date": "2024-03-22",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-03-22/",
+              "title": "2024-03-22",
+              "topic": "🎦观影杂感",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-02-20",
+          "date": "2024-02-20",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-02-20/",
+              "title": "2024-02-20",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-02-12",
+          "date": "2024-02-12",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-02-12/",
+              "title": "2024-02-12",
+              "topic": "🧨过年啦",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-02-10",
+          "date": "2024-02-10",
+          "duplicate_count": 2,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-02-10-01/",
+              "title": "2024-02-10 #1",
+              "topic": "📓我的年度总结",
+              "sequence_label": "01"
+            },
+            {
+              "path": "/gcores-talks/2024-02-10-02/",
+              "title": "2024-02-10 #2",
+              "topic": "📓我的年度总结",
+              "sequence_label": "02"
+            }
+          ]
+        },
+        {
+          "label": "2024-02-03",
+          "date": "2024-02-03",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-02-03/",
+              "title": "2024-02-03",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-02-02",
+          "date": "2024-02-02",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-02-02/",
+              "title": "2024-02-02",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-02-01",
+          "date": "2024-02-01",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-02-01/",
+              "title": "2024-02-01",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-01-31",
+          "date": "2024-01-31",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-01-31/",
+              "title": "2024-01-31",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-01-23",
+          "date": "2024-01-23",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-01-23/",
+              "title": "2024-01-23",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-01-19",
+          "date": "2024-01-19",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-01-19/",
+              "title": "2024-01-19",
+              "topic": "🏆2023我最喜欢的5款游戏",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-01-13",
+          "date": "2024-01-13",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-01-13/",
+              "title": "2024-01-13",
+              "topic": "🎮关于这个游戏的感受",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-01-06",
+          "date": "2024-01-06",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-01-06/",
+              "title": "2024-01-06",
+              "topic": "🧚俗世奇人",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-01-02",
+          "date": "2024-01-02",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-01-02/",
+              "title": "2024-01-02",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2024-01-01",
+          "date": "2024-01-01",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2024-01-01/",
+              "title": "2024-01-01",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "2023",
+      "dates": [
+        {
+          "label": "2023-12-29",
+          "date": "2023-12-29",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-12-29/",
+              "title": "2023-12-29",
+              "topic": "💪FLAG打卡记录站",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-11-21",
+          "date": "2023-11-21",
+          "duplicate_count": 2,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-11-21-01/",
+              "title": "2023-11-21 #1",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": "01"
+            },
+            {
+              "path": "/gcores-talks/2023-11-21-02/",
+              "title": "2023-11-21 #2",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": "02"
+            }
+          ]
+        },
+        {
+          "label": "2023-11-18",
+          "date": "2023-11-18",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-11-18/",
+              "title": "2023-11-18",
+              "topic": "🥘机组美食城",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-10-31",
+          "date": "2023-10-31",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-10-31/",
+              "title": "2023-10-31",
+              "topic": "🧳出去走走",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-10-17",
+          "date": "2023-10-17",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-10-17/",
+              "title": "2023-10-17",
+              "topic": "🌕午夜诗人",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-10-10",
+          "date": "2023-10-10",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-10-10/",
+              "title": "2023-10-10",
+              "topic": "🎵这周听了啥",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-10-04",
+          "date": "2023-10-04",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-10-04/",
+              "title": "2023-10-04",
+              "topic": "✨日子人的生活小妙招",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-10-02",
+          "date": "2023-10-02",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-10-02/",
+              "title": "2023-10-02",
+              "topic": "🆚印象深刻的电竞赛事",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-09-28",
+          "date": "2023-09-28",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-09-28/",
+              "title": "2023-09-28",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-09-16",
+          "date": "2023-09-16",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-09-16/",
+              "title": "2023-09-16",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-09-13",
+          "date": "2023-09-13",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-09-13/",
+              "title": "2023-09-13",
+              "topic": "🍡怪物猎人 崛起",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-08-22",
+          "date": "2023-08-22",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-08-22/",
+              "title": "2023-08-22",
+              "topic": "🚴飙速宅男",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-08-15",
+          "date": "2023-08-15",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-08-15/",
+              "title": "2023-08-15",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-08-12",
+          "date": "2023-08-12",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-08-12/",
+              "title": "2023-08-12",
+              "topic": "🍺都在酒里",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-08-04",
+          "date": "2023-08-04",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-08-04/",
+              "title": "2023-08-04",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-07-21",
+          "date": "2023-07-21",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-07-21/",
+              "title": "2023-07-21",
+              "topic": "🍙动画打卡",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-07-18",
+          "date": "2023-07-18",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-07-18/",
+              "title": "2023-07-18",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-07-09",
+          "date": "2023-07-09",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-07-09/",
+              "title": "2023-07-09",
+              "topic": "🍵饮茶Time",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-07-07",
+          "date": "2023-07-07",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-07-07/",
+              "title": "2023-07-07",
+              "topic": "🐟社畜茶水间",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-07-02",
+          "date": "2023-07-02",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-07-02/",
+              "title": "2023-07-02",
+              "topic": "🎵这周听了啥",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-07-01",
+          "date": "2023-07-01",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-07-01/",
+              "title": "2023-07-01",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-06-29",
+          "date": "2023-06-29",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-06-29/",
+              "title": "2023-06-29",
+              "topic": "😎显摆显摆",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-06-27",
+          "date": "2023-06-27",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-06-27/",
+              "title": "2023-06-27",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-06-26",
+          "date": "2023-06-26",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-06-26/",
+              "title": "2023-06-26",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-06-20",
+          "date": "2023-06-20",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-06-20/",
+              "title": "2023-06-20",
+              "topic": "🎵这周听了啥",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-06-19",
+          "date": "2023-06-19",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-06-19/",
+              "title": "2023-06-19",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-06-18",
+          "date": "2023-06-18",
+          "duplicate_count": 2,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-06-18-01/",
+              "title": "2023-06-18 #1",
+              "topic": "🎦观影杂感",
+              "sequence_label": "01"
+            },
+            {
+              "path": "/gcores-talks/2023-06-18-02/",
+              "title": "2023-06-18 #2",
+              "topic": "💪FLAG打卡记录站",
+              "sequence_label": "02"
+            }
+          ]
+        },
+        {
+          "label": "2023-06-15",
+          "date": "2023-06-15",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-06-15/",
+              "title": "2023-06-15",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-06-13",
+          "date": "2023-06-13",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-06-13/",
+              "title": "2023-06-13",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-06-12",
+          "date": "2023-06-12",
+          "duplicate_count": 2,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-06-12-01/",
+              "title": "2023-06-12 #1",
+              "topic": "💪FLAG打卡记录站",
+              "sequence_label": "01"
+            },
+            {
+              "path": "/gcores-talks/2023-06-12-02/",
+              "title": "2023-06-12 #2",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": "02"
+            }
+          ]
+        },
+        {
+          "label": "2023-06-10",
+          "date": "2023-06-10",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-06-10/",
+              "title": "2023-06-10",
+              "topic": "🏅️程序猿杰作",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-06-09",
+          "date": "2023-06-09",
+          "duplicate_count": 2,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-06-09-01/",
+              "title": "2023-06-09 #1",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": "01"
+            },
+            {
+              "path": "/gcores-talks/2023-06-09-02/",
+              "title": "2023-06-09 #2",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": "02"
+            }
+          ]
+        },
+        {
+          "label": "2023-06-07",
+          "date": "2023-06-07",
+          "duplicate_count": 2,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-06-07-01/",
+              "title": "2023-06-07 #1",
+              "topic": "🎵这周听了啥",
+              "sequence_label": "01"
+            },
+            {
+              "path": "/gcores-talks/2023-06-07-02/",
+              "title": "2023-06-07 #2",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": "02"
+            }
+          ]
+        },
+        {
+          "label": "2023-06-05",
+          "date": "2023-06-05",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-06-05/",
+              "title": "2023-06-05",
+              "topic": "🕺宅宅也能帅",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-06-03",
+          "date": "2023-06-03",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-06-03/",
+              "title": "2023-06-03",
+              "topic": "🎦观影杂感",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-06-01",
+          "date": "2023-06-01",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-06-01/",
+              "title": "2023-06-01",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-05-30",
+          "date": "2023-05-30",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-05-30/",
+              "title": "2023-05-30",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-05-24",
+          "date": "2023-05-24",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-05-24/",
+              "title": "2023-05-24",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-05-21",
+          "date": "2023-05-21",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-05-21/",
+              "title": "2023-05-21",
+              "topic": "🍿️追剧狂人",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-05-18",
+          "date": "2023-05-18",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-05-18/",
+              "title": "2023-05-18",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-05-13",
+          "date": "2023-05-13",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-05-13/",
+              "title": "2023-05-13",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-05-06",
+          "date": "2023-05-06",
+          "duplicate_count": 2,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-05-06-01/",
+              "title": "2023-05-06 #1",
+              "topic": "🥘机组美食城",
+              "sequence_label": "01"
+            },
+            {
+              "path": "/gcores-talks/2023-05-06-02/",
+              "title": "2023-05-06 #2",
+              "topic": "🔖这段太精彩了",
+              "sequence_label": "02"
+            }
+          ]
+        },
+        {
+          "label": "2023-05-05",
+          "date": "2023-05-05",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-05-05/",
+              "title": "2023-05-05",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-04-23",
+          "date": "2023-04-23",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-04-23/",
+              "title": "2023-04-23",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-04-20",
+          "date": "2023-04-20",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-04-20/",
+              "title": "2023-04-20",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-04-14",
+          "date": "2023-04-14",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-04-14/",
+              "title": "2023-04-14",
+              "topic": "🎮关于这个游戏的感受",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-04-12",
+          "date": "2023-04-12",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-04-12/",
+              "title": "2023-04-12",
+              "topic": "🧩碎片故事",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-03-27",
+          "date": "2023-03-27",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-03-27/",
+              "title": "2023-03-27",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-03-19",
+          "date": "2023-03-19",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-03-19/",
+              "title": "2023-03-19",
+              "topic": "🧩碎片故事",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-02-07",
+          "date": "2023-02-07",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-02-07/",
+              "title": "2023-02-07",
+              "topic": "🎮关于这个游戏的感受",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-01-20",
+          "date": "2023-01-20",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-01-20/",
+              "title": "2023-01-20",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": ""
+            }
+          ]
+        },
+        {
+          "label": "2023-01-15",
+          "date": "2023-01-15",
+          "duplicate_count": 3,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-01-15-01/",
+              "title": "2023-01-15 #1",
+              "topic": "🔧手艺人",
+              "sequence_label": "01"
+            },
+            {
+              "path": "/gcores-talks/2023-01-15-02/",
+              "title": "2023-01-15 #2",
+              "topic": "🧩一枚生活碎片",
+              "sequence_label": "02"
+            },
+            {
+              "path": "/gcores-talks/2023-01-15-03/",
+              "title": "2023-01-15 #3",
+              "topic": "🍙动画打卡",
+              "sequence_label": "03"
+            }
+          ]
+        },
+        {
+          "label": "2023-01-04",
+          "date": "2023-01-04",
+          "duplicate_count": 1,
+          "entries": [
+            {
+              "path": "/gcores-talks/2023-01-04/",
+              "title": "2023-01-04",
+              "topic": "🧚俗世奇人",
+              "sequence_label": ""
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/split-daily-logs.mjs
+++ b/scripts/split-daily-logs.mjs
@@ -291,6 +291,59 @@ async function writeDailyIndex(data) {
   await writeFile(path.join(dataDir, "daily-index.json"), JSON.stringify(data, null, 2));
 }
 
+function buildDailyToc(entries, { groupBy }) {
+  const dateCounts = entries.reduce((memo, entry) => {
+    memo.set(entry.date, (memo.get(entry.date) ?? 0) + 1);
+    return memo;
+  }, new Map());
+  const groups = [];
+  const groupMap = new Map();
+
+  entries.forEach((entry) => {
+    const groupLabel = groupBy === "year" ? entry.date.slice(0, 4) : entry.date.slice(0, 7);
+    const dateLabel = groupBy === "year" ? entry.date : entry.date.slice(5);
+    const duplicateCount = dateCounts.get(entry.date) ?? 1;
+
+    if (!groupMap.has(groupLabel)) {
+      const group = { label: groupLabel, dates: [] };
+      groups.push(group);
+      groupMap.set(groupLabel, { group, dateMap: new Map() });
+    }
+
+    const groupRecord = groupMap.get(groupLabel);
+    if (!groupRecord.dateMap.has(entry.date)) {
+      const dateGroup = {
+        label: dateLabel,
+        date: entry.date,
+        duplicate_count: duplicateCount,
+        entries: [],
+      };
+      groupRecord.group.dates.push(dateGroup);
+      groupRecord.dateMap.set(entry.date, dateGroup);
+    }
+
+    groupRecord.dateMap.get(entry.date).entries.push({
+      path: entry.path,
+      title: entry.title,
+      topic: entry.topic ?? "",
+      sequence_label: duplicateCount > 1 ? pad(entry.sequence ?? 1) : "",
+    });
+  });
+
+  return groups;
+}
+
+async function writeDailyToc(data) {
+  await writeFile(
+    path.join(dataDir, "daily-toc.json"),
+    JSON.stringify({
+      "diary-2020": buildDailyToc(data["diary-2020"], { groupBy: "month" }),
+      "diary-2026": buildDailyToc(data["diary-2026"], { groupBy: "month" }),
+      gcores: buildDailyToc(data.gcores, { groupBy: "year" }),
+    }, null, 2)
+  );
+}
+
 async function writeDiaryIndex() {
   await writeFile(
     path.join(contentDir, "diary", "_index.md"),
@@ -322,14 +375,16 @@ async function writeCompatibilityPage(year) {
 const diary2020 = await splitDiaryYear(2020, "2020 工作日志", ["工作日志", "月度总结", "技术"]);
 const diary2026 = await splitDiaryYear(2026, "2026 工作日志", ["工作日志"]);
 const gcores = await splitGcores();
-await writeDiaryIndex();
-await writeCompatibilityPage(2020);
-await writeCompatibilityPage(2026);
-await writeDailyIndex({
+const dailyIndex = {
   "diary-2020": diary2020,
   "diary-2026": diary2026,
   gcores,
-});
+};
+await writeDiaryIndex();
+await writeCompatibilityPage(2020);
+await writeCompatibilityPage(2026);
+await writeDailyIndex(dailyIndex);
+await writeDailyToc(dailyIndex);
 
 console.log(`Generated ${diary2020.length} diary-2020 entries`);
 console.log(`Generated ${diary2026.length} diary-2026 entries`);

--- a/themes/cone-scroll/static/css/style.css
+++ b/themes/cone-scroll/static/css/style.css
@@ -398,6 +398,156 @@ main {
   color: var(--fg);
 }
 
+.daily-shell {
+  width: 100%;
+  max-width: 1040px;
+  min-width: 0;
+}
+
+.daily-head {
+  max-width: 70ch;
+  margin-bottom: 2.35rem;
+}
+
+.daily-head-copy {
+  max-width: 69ch;
+}
+
+.daily-count {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem 1rem;
+  margin: 1rem 0 0;
+  color: var(--muted-strong);
+  font-size: 0.9rem;
+}
+
+.daily-layout {
+  display: block;
+  min-width: 0;
+}
+
+.daily-outline {
+  margin-bottom: 1.8rem;
+}
+
+.daily-outline summary {
+  letter-spacing: 0;
+}
+
+.daily-outline-group,
+.daily-outline-date {
+  color: var(--muted-strong);
+  font-weight: 600;
+}
+
+.daily-outline-date {
+  display: block;
+}
+
+.daily-outline-entry {
+  overflow-wrap: anywhere;
+}
+
+.daily-outline-seq,
+.daily-outline-topic {
+  color: var(--muted);
+}
+
+.daily-outline-seq {
+  margin-right: 0.4rem;
+}
+
+.daily-outline-topic {
+  display: block;
+  margin-top: 0.05rem;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.daily-outline-sequences {
+  margin-top: 0.35rem;
+}
+
+.daily-feed {
+  max-width: 69ch;
+  min-width: 0;
+}
+
+.daily-entry-list,
+.daily-entry-card,
+.daily-entry-content {
+  min-width: 0;
+}
+
+.daily-entry-card {
+  margin: 0 0 2rem;
+  padding: 0 0 2rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.daily-entry-card:last-child {
+  border-bottom: none;
+}
+
+.daily-entry-card-head {
+  margin-bottom: 0.75rem;
+}
+
+.daily-entry-card h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1.24em;
+  line-height: 1.55;
+  letter-spacing: 0;
+}
+
+.daily-entry-card h2 a {
+  color: var(--fg);
+  text-decoration: none;
+}
+
+.daily-entry-card h2 a:hover,
+.daily-entry-card h2 a:focus {
+  color: var(--link);
+  text-decoration: underline;
+}
+
+.daily-entry-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 0.75rem;
+  margin: 0;
+  color: var(--muted-strong);
+  font-size: 0.9rem;
+}
+
+.daily-entry-content {
+  overflow-wrap: anywhere;
+}
+
+.daily-entry-content > :first-child {
+  margin-top: 0;
+}
+
+.daily-entry-content > :last-child {
+  margin-bottom: 0;
+}
+
+.daily-entry-actions {
+  margin-top: 0.8rem;
+  font-size: 0.9rem;
+}
+
+.daily-pagination {
+  margin-top: 1.5rem;
+}
+
+.daily-load-status {
+  color: var(--muted-strong);
+  font-size: 0.9rem;
+}
+
 footer {
   margin-top: 3rem;
   padding-top: 1rem;
@@ -484,6 +634,24 @@ footer nav + p {
   .page-shell.has-outline[data-outline-state="collapsed"] .page-article {
     max-width: 70ch;
     padding-top: 1.7rem;
+  }
+
+  .daily-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 15rem) minmax(0, 1fr);
+    column-gap: 2.75rem;
+    align-items: start;
+  }
+
+  .daily-outline {
+    position: sticky;
+    top: 1.75rem;
+    max-height: calc(100vh - 3.5rem);
+    margin: 0;
+    padding-right: 1.65rem;
+    border-right: 1px solid var(--border);
+    overflow-y: auto;
+    overscroll-behavior: contain;
   }
 }
 
@@ -1271,5 +1439,18 @@ address.post-meta {
     min-width: 0;
     margin-top: 0.35rem;
     box-shadow: none;
+  }
+
+  .daily-head {
+    margin-bottom: 1.65rem;
+  }
+
+  .daily-outline {
+    margin: 0.65rem 0 1.4rem;
+  }
+
+  .daily-entry-card {
+    margin-bottom: 1.65rem;
+    padding-bottom: 1.65rem;
   }
 }

--- a/themes/cone-scroll/static/js/script.js
+++ b/themes/cone-scroll/static/js/script.js
@@ -272,21 +272,6 @@
 
   function initDailyArchive() {
     document.querySelectorAll("[data-daily-archive]").forEach((archive) => {
-      const jumpSelect = archive.querySelector("[data-daily-jump-select]");
-      const jumpOpen = archive.querySelector("[data-daily-jump-open]");
-
-      if (jumpSelect && jumpOpen && jumpSelect.getAttribute("data-daily-jump-bound") !== "true") {
-        const syncJumpLink = function () {
-          if (jumpSelect.value) {
-            jumpOpen.setAttribute("href", jumpSelect.value);
-          }
-        };
-
-        jumpSelect.setAttribute("data-daily-jump-bound", "true");
-        jumpSelect.addEventListener("change", syncJumpLink);
-        syncJumpLink();
-      }
-
       if (archive.getAttribute("data-infinite-bound") === "true") {
         return;
       }

--- a/themes/cone-scroll/templates/daily-archive.html
+++ b/themes/cone-scroll/templates/daily-archive.html
@@ -9,20 +9,19 @@
   {% set entries = section.pages %}
 {% endif %}
 {% set daily_index = load_data(path="data/daily-index.json") %}
+{% set daily_toc = load_data(path="data/daily-toc.json") %}
 {% set jump_entries = [] %}
+{% set toc_groups = [] %}
 {% if section.extra.daily_index_key == "diary-2020" %}
   {% set jump_entries = daily_index["diary-2020"] %}
+  {% set toc_groups = daily_toc["diary-2020"] %}
 {% elif section.extra.daily_index_key == "diary-2026" %}
   {% set jump_entries = daily_index["diary-2026"] %}
+  {% set toc_groups = daily_toc["diary-2026"] %}
 {% elif section.extra.daily_index_key == "gcores" %}
   {% set jump_entries = daily_index.gcores %}
+  {% set toc_groups = daily_toc.gcores %}
 {% endif %}
-{% set first_entry_url = section.permalink %}
-{% for entry in jump_entries %}
-  {% if loop.first %}
-    {% set_global first_entry_url = entry.path %}
-  {% endif %}
-{% endfor %}
 {% if section.extra.daily_source == "diary" %}
   {% set parent_href = get_url(path="@/diary/_index.md", lang=link_lang) %}
   {% set parent_label = "日志归档" %}
@@ -50,23 +49,42 @@
   </header>
 
   <div class="daily-layout">
-    <aside class="daily-tools" aria-label="日志工具">
-      <details class="daily-jump" open>
-        <summary>查日期</summary>
-        <div class="daily-jump-body">
-          <label class="daily-jump-label" for="daily-jump-select">选择日期</label>
-          <select id="daily-jump-select" class="daily-jump-select" data-daily-jump-select>
-            {% for entry in jump_entries %}
-              <option value="{{ entry.path | safe }}">{{ entry.title }}{% if entry.topic %} · {{ entry.topic }}{% endif %}</option>
+    <aside class="page-outline daily-outline" aria-label="日期目录">
+      <details class="page-outline-panel daily-outline-panel" open>
+        <summary class="page-outline-toggle">日期目录</summary>
+        <nav class="page-outline-nav daily-outline-nav" aria-label="{{ section.title }} 日期目录">
+          <ol>
+            {% for group in toc_groups %}
+              <li>
+                <span class="daily-outline-group">{{ group.label }}</span>
+                <ol>
+                  {% for date_group in group.dates %}
+                    <li>
+                      {% if date_group.entries | length > 1 %}
+                        <span class="daily-outline-date">{{ date_group.label }}</span>
+                        <ol class="daily-outline-sequences">
+                          {% for item in date_group.entries %}
+                            <li>
+                              <a class="daily-outline-entry" href="{{ item.path | safe }}">
+                                <span class="daily-outline-seq">{{ item.sequence_label }}</span>{% if item.topic %}<span>{{ item.topic }}</span>{% else %}<span>{{ item.title }}</span>{% endif %}
+                              </a>
+                            </li>
+                          {% endfor %}
+                        </ol>
+                      {% else %}
+                        {% for item in date_group.entries %}
+                          <a href="{{ item.path | safe }}">{{ date_group.label }}</a>
+                          {% if item.topic %}<span class="daily-outline-topic">{{ item.topic }}</span>{% endif %}
+                        {% endfor %}
+                      {% endif %}
+                    </li>
+                  {% endfor %}
+                </ol>
+              </li>
             {% endfor %}
-          </select>
-          <a class="daily-jump-open" data-daily-jump-open href="{{ first_entry_url | safe }}">打开</a>
-        </div>
+          </ol>
+        </nav>
       </details>
-
-      <div class="daily-tool-note">
-        <p>每日入口已经拆成独立页面。这里保留连续阅读，向下滚动会继续加载下一页。</p>
-      </div>
     </aside>
 
     <section class="daily-feed" aria-label="{{ section.title }}">


### PR DESCRIPTION
## Summary

- Replace the daily archive select picker with a document-style date TOC.
- Add grouped TOC data for diary and Gcores archives, including same-day sequence entries.
- Keep the existing static paginator and infinite-loading enhancement.

## Validation

- `git diff --check`
- `nix-shell --run 'zola build'`
- Playwright screenshots for `/gcores-talks/`, `/diary/2020/`, and `/diary/2026/` at `393x852`, `1440x900`, and `2560x1440`

## Notes

- `scripts/split-daily-logs.mjs` was updated for future regeneration, but the full script cannot be run in this worktree because `scripts/daily-sources/*` is absent.
