### PR TITLE
Fix daily TOC desktop breakpoint

### DIFF
--- a/.legion/tasks/daily-toc-desktop-layout-fix/docs/pr-body.md
+++ b/.legion/tasks/daily-toc-desktop-layout-fix/docs/pr-body.md
@@ -1,0 +1,19 @@
+## Summary
+
+- Fix the daily archive TOC breakpoint mismatch with the approved dummy.
+- Make daily archive pages switch to left TOC rail + right feed at `880px`.
+- Keep iPhone-sized screens as top TOC + feed and leave normal article outline behavior unchanged.
+
+## Validation
+
+- `nix-shell --run 'zola build'`
+- Playwright computed layout assertions for `/gcores-talks/`, `/diary/2020/`, and `/diary/2026/` at:
+  - `393x852`: expected top/bottom
+  - `900x900`: expected left/right
+  - `1440x900`: expected left/right
+  - `2560x1440`: expected left/right
+- Playwright infinite loading smoke test on `/gcores-talks/`: `8 -> 16` entries after clicking `继续加载`
+
+## Notes
+
+The previous implementation was readable at tested sizes, but it did not assert the actual layout mode. This PR adds the missing responsive behavior and records that desktop/laptop checks must verify left/right TOC placement, not just absence of overlap.

--- a/.legion/tasks/daily-toc-desktop-layout-fix/docs/report-walkthrough.md
+++ b/.legion/tasks/daily-toc-desktop-layout-fix/docs/report-walkthrough.md
@@ -1,0 +1,31 @@
+# Report Walkthrough
+
+Mode: implementation.
+
+## Summary
+
+Fixes the daily archive TOC responsive mismatch. The approved dummy used a left/right layout at desktop-like widths, but production only switched to grid at `960px`, so some 13-inch or sidebar-constrained browser windows showed the TOC above the feed.
+
+## Delivery
+
+- Daily archive grid now starts at `880px`.
+- The daily rail and layout gap are fluid near the breakpoint and return to the established dimensions on wider screens.
+- Normal article outline behavior remains unchanged.
+
+## Evidence
+
+- Test report: `.legion/tasks/daily-toc-desktop-layout-fix/docs/test-report.md`
+- Review: `.legion/tasks/daily-toc-desktop-layout-fix/docs/review-change.md`
+- Changed file: `themes/cone-scroll/static/css/style.css`
+
+## Verification Highlights
+
+- iPhone-sized `393x852`: TOC remains above feed.
+- Narrow desktop `900x900`: TOC is left rail, feed is right column.
+- 13-inch `1440x900`: TOC is left rail, feed is right column.
+- 27-inch `2560x1440`: TOC is left rail, feed is right column.
+- Infinite loading smoke test passed: `8 -> 16` entries after clicking `继续加载`.
+
+## Lifecycle
+
+This task is PR-backed. Completion requires PR merge, cleanup, and main workspace refresh.

--- a/.legion/tasks/daily-toc-desktop-layout-fix/docs/review-change.md
+++ b/.legion/tasks/daily-toc-desktop-layout-fix/docs/review-change.md
@@ -1,0 +1,35 @@
+# Review Change
+
+## Decision
+
+PASS.
+
+## Scope
+
+In scope:
+
+- Daily archive layout CSS only.
+- Preserve existing TOC visual language.
+- Preserve mobile in-flow outline.
+- Preserve infinite loading behavior.
+
+Out of scope and not changed:
+
+- Normal article outline breakpoint.
+- Daily archive template structure.
+- URL structure, pagination data, and split-log generation.
+
+## Findings
+
+No blocking findings.
+
+## Review Notes
+
+- The root cause is correctly addressed: daily archive grid activation now starts at `880px`, matching the approved dummy behavior instead of the previous production-only `960px` threshold.
+- The rail and gap are fluid near the threshold, reducing the risk that the earlier breakpoint makes the feed too narrow.
+- The original `960px` breakpoint for `.page-shell.has-outline` remains untouched, so this fix does not expand the behavior of normal article outline pages.
+- No security-sensitive paths are affected. This is static CSS for a public archive surface.
+
+## Residual Risk
+
+Browser UI chrome and user sidebars can still reduce viewport width below `880px`; under that width the page intentionally becomes top/bottom to protect mobile and narrow-window readability.

--- a/.legion/tasks/daily-toc-desktop-layout-fix/docs/test-report.md
+++ b/.legion/tasks/daily-toc-desktop-layout-fix/docs/test-report.md
@@ -1,0 +1,62 @@
+# Test Report
+
+## Result
+
+PASS.
+
+## Commands
+
+```bash
+nix-shell --run 'zola build'
+```
+
+Result: PASS. Zola 0.21.0 built 257 pages and 9 sections.
+
+```bash
+NODE_PATH=/Users/c1/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/node_modules \
+  /Users/c1/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node <playwright-layout-assertions>
+```
+
+Result: PASS using local Chrome channel.
+
+Checked pages:
+
+- `/gcores-talks/`
+- `/diary/2020/`
+- `/diary/2026/`
+
+Checked viewports:
+
+- iPhone-sized: `393x852`, expected `.daily-layout` display `block`
+- Narrow desktop threshold: `900x900`, expected `.daily-layout` display `grid`
+- 13-inch laptop: `1440x900`, expected `.daily-layout` display `grid`
+- 27-inch desktop: `2560x1440`, expected `.daily-layout` display `grid`
+
+All page/viewport pairs passed:
+
+- expected layout mode matched computed style
+- TOC and feed positions matched the expected top/bottom or left/right relationship
+- no horizontal overflow
+- `[data-infinite-next]` remained present
+
+```bash
+NODE_PATH=/Users/c1/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/node_modules \
+  /Users/c1/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node <playwright-infinite-load-smoke>
+```
+
+Result: PASS. On `/gcores-talks/` at `1440x900`, entry cards increased from 8 to 16 after clicking `继续加载`.
+
+## Visual Check
+
+Representative screenshots were inspected for:
+
+- `900x900` Gcores: left date TOC rail plus right feed
+- `1440x900` Gcores: left/right layout with readable feed width
+- `2560x1440` Gcores: centered shell, left/right layout preserved
+- `393x852` Gcores: TOC remains in flow above the feed
+
+Screenshots were used as local verification artifacts and are not intended as committed deliverables.
+
+## Why These Checks
+
+The bug was a responsive behavior mismatch, so computed layout assertions are stronger than a generic build. The extra `900x900` viewport specifically covers the range where the dummy already used a rail but production previously fell back to top/bottom.

--- a/.legion/tasks/daily-toc-desktop-layout-fix/log.md
+++ b/.legion/tasks/daily-toc-desktop-layout-fix/log.md
@@ -1,0 +1,9 @@
+# Log
+
+## 2026-06-10
+
+- User reported that the shipped TOC appears as top/bottom rather than the left/right dummy layout.
+- Diagnosis: production `.daily-layout` grid is gated behind `@media (min-width: 960px)`, while the approved dummy uses `880px`; real browser chrome/sidebars can put a 13-inch use case below 960px.
+- Created isolated worktree `daily-toc-desktop-layout-fix` from `origin/master`.
+- Patched daily-only CSS to use an `880px` grid breakpoint with fluid rail/gap sizing.
+- Verified with Zola build, computed layout assertions across three daily archive pages and four viewport sizes, visual screenshots, and an infinite loading smoke test.

--- a/.legion/tasks/daily-toc-desktop-layout-fix/plan.md
+++ b/.legion/tasks/daily-toc-desktop-layout-fix/plan.md
@@ -1,0 +1,51 @@
+# daily-toc-desktop-layout-fix
+
+## Goal
+
+Make the shipped daily archive TOC match the approved dummy behavior: desktop and laptop widths use a left date TOC rail with the feed on the right, while phone widths keep the TOC in document flow above the feed.
+
+## Problem
+
+The implementation merged in PR #7 validates that the daily TOC is readable, but the production CSS only switches `.daily-layout` to a two-column grid at `960px`. The dummy design switches at `880px`. In real browser chrome or side-pane contexts, a 13-inch screen can leave less than `960px` of page viewport, so the production page falls back to an unintended top/bottom layout even though the approved dummy is already two-column.
+
+## Acceptance
+
+- `/gcores-talks/`, `/diary/2020/`, and `/diary/2026/` render as left TOC rail plus right feed at 13-inch and 27-inch desktop viewports.
+- The same pages render as top TOC plus feed on an iPhone-sized viewport without horizontal scrolling.
+- The fix keeps the existing document TOC style: plain text, thin rule, no cards, no select picker, no decorative UI.
+- Infinite loading remains intact.
+- Zola build passes.
+
+## Scope
+
+- Adjust the daily archive layout CSS only.
+- Keep the existing `daily-archive.html` structure unless verification proves a template change is required.
+- Record verification evidence for the three requested page sizes.
+
+## Non-goals
+
+- Do not redesign the daily archive again.
+- Do not change normal article outline behavior.
+- Do not change URL structure, pagination, or daily log splitting.
+
+## Assumptions
+
+- The approved dummy breakpoint is the intended desktop/laptop behavior.
+- Phone-sized screens should not use a two-column rail because it would reduce reading width and tap target quality.
+- A slightly fluid rail/gap is acceptable if it preserves the same visual language.
+
+## Risks
+
+- Moving the breakpoint earlier can make the feed too narrow near the threshold if the rail and gap remain fixed.
+- A CSS-only fix can pass build but still fail real visual expectations, so screenshot assertions are required.
+
+## Design Summary
+
+Use the dummy's `880px` daily breakpoint, but make the daily rail and gap responsive so the layout still breathes on 13-inch windows and stays stable on 27-inch monitors. Keep mobile under the breakpoint as an in-flow outline.
+
+## Phases
+
+1. Diagnose CSS and dummy mismatch.
+2. Patch daily-only layout CSS.
+3. Build and run visual verification at iPhone, 13-inch, and 27-inch sizes.
+4. Review, document, push PR, and follow merge lifecycle.

--- a/.legion/tasks/daily-toc-desktop-layout-fix/tasks.md
+++ b/.legion/tasks/daily-toc-desktop-layout-fix/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+- [x] Brainstorm: stabilize contract for the daily TOC layout mismatch.
+- [x] Engineer: patch daily-only CSS to match approved desktop/laptop behavior.
+- [x] Verify: run build and three-size visual checks.
+- [x] Review: check scope, regressions, and implementation/design alignment.
+- [x] Report: write reviewer handoff and PR body.
+- [ ] Wiki: record durable task summary.
+- [ ] Git lifecycle: commit, rebase, push, PR, auto-merge/checks, cleanup, main refresh.

--- a/.legion/wiki/index.md
+++ b/.legion/wiki/index.md
@@ -4,6 +4,7 @@
 
 - `tasks/daily-log-split-design.md`: Daily log split architecture and viewport validation decisions.
 - `tasks/daily-log-toc-implementation.md`: Daily archive TOC implementation and duplicate-date sequence rule.
+- `tasks/daily-toc-desktop-layout-fix.md`: Daily archive TOC breakpoint correction after production/demo mismatch.
 - `patterns.md`: Reusable theme and archive implementation conventions.
 - `maintenance.md`: Follow-up implementation backlog.
 

--- a/.legion/wiki/log.md
+++ b/.legion/wiki/log.md
@@ -8,3 +8,5 @@
 - Added task summary for `daily-log-toc-implementation`.
 - Promoted the daily archive TOC pattern: document-outline navigation, plain date links, duplicate-date sequence labels, static pagination preserved.
 - Updated daily-log maintenance backlog after TOC implementation.
+- Added task summary for `daily-toc-desktop-layout-fix`.
+- Promoted a daily archive responsive verification rule: desktop/laptop checks must assert left/right TOC placement, not just visual non-overlap.

--- a/.legion/wiki/patterns.md
+++ b/.legion/wiki/patterns.md
@@ -31,6 +31,8 @@ For daily archive navigation, prefer document-outline navigation over form contr
 - group duplicate-date sources under the date with stable sequence labels
 - keep mobile access in normal document flow with native `<details>`
 - keep desktop access as a sticky left rail with a thin divider
+- verify desktop/laptop archive pages by asserting left/right placement, not only by checking that screenshots have no overlap
+- keep the daily archive rail breakpoint aligned with the approved dummy behavior unless a new design explicitly changes it
 
 ## Terminal-Paper UI Preservation
 

--- a/.legion/wiki/tasks/daily-toc-desktop-layout-fix.md
+++ b/.legion/wiki/tasks/daily-toc-desktop-layout-fix.md
@@ -1,0 +1,23 @@
+# daily-toc-desktop-layout-fix
+
+## Status
+
+Implemented and verified; pending PR lifecycle at time of writeback.
+
+## Problem
+
+The daily archive TOC implementation used `960px` as the grid breakpoint, while the approved dummy used `880px`. This made some desktop-like browser contexts, especially 13-inch or sidebar-constrained windows, render the TOC above the feed instead of as a left rail.
+
+## Decision
+
+Daily archive pages use a daily-specific `880px` grid breakpoint. The rail width and gap are fluid near the threshold and settle back to the original desktop proportions on wider screens.
+
+Normal article outline breakpoint remains unchanged.
+
+## Verification
+
+- `zola build` passed.
+- `/gcores-talks/`, `/diary/2020/`, and `/diary/2026/` passed layout assertions at `393x852`, `900x900`, `1440x900`, and `2560x1440`.
+- `393x852` intentionally remains top/bottom.
+- `900x900`, `1440x900`, and `2560x1440` are left/right.
+- Infinite loading smoke test passed.

--- a/themes/cone-scroll/static/css/style.css
+++ b/themes/cone-scroll/static/css/style.css
@@ -402,6 +402,8 @@ main {
   width: 100%;
   max-width: 1040px;
   min-width: 0;
+  --daily-rail-width: clamp(12rem, 24vw, 15rem);
+  --daily-layout-gap: clamp(1.6rem, 4vw, 2.75rem);
 }
 
 .daily-head {
@@ -548,6 +550,26 @@ main {
   font-size: 0.9rem;
 }
 
+@media (min-width: 880px) {
+  .daily-layout {
+    display: grid;
+    grid-template-columns: minmax(0, var(--daily-rail-width)) minmax(0, 1fr);
+    column-gap: var(--daily-layout-gap);
+    align-items: start;
+  }
+
+  .daily-outline {
+    position: sticky;
+    top: 1.75rem;
+    max-height: calc(100vh - 3.5rem);
+    margin: 0;
+    padding-right: clamp(1rem, 2.5vw, 1.65rem);
+    border-right: 1px solid var(--border);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+}
+
 footer {
   margin-top: 3rem;
   padding-top: 1rem;
@@ -636,23 +658,6 @@ footer nav + p {
     padding-top: 1.7rem;
   }
 
-  .daily-layout {
-    display: grid;
-    grid-template-columns: minmax(0, 15rem) minmax(0, 1fr);
-    column-gap: 2.75rem;
-    align-items: start;
-  }
-
-  .daily-outline {
-    position: sticky;
-    top: 1.75rem;
-    max-height: calc(100vh - 3.5rem);
-    margin: 0;
-    padding-right: 1.65rem;
-    border-right: 1px solid var(--border);
-    overflow-y: auto;
-    overscroll-behavior: contain;
-  }
 }
 
 @media (prefers-reduced-motion: no-preference) {


### PR DESCRIPTION
## Summary

- Fix the daily archive TOC breakpoint mismatch with the approved dummy.
- Make daily archive pages switch to left TOC rail + right feed at `880px`.
- Keep iPhone-sized screens as top TOC + feed and leave normal article outline behavior unchanged.

## Validation

- `nix-shell --run 'zola build'`
- Playwright computed layout assertions for `/gcores-talks/`, `/diary/2020/`, and `/diary/2026/` at:
  - `393x852`: expected top/bottom
  - `900x900`: expected left/right
  - `1440x900`: expected left/right
  - `2560x1440`: expected left/right
- Playwright infinite loading smoke test on `/gcores-talks/`: `8 -> 16` entries after clicking `继续加载`

## Notes

The previous implementation was readable at tested sizes, but it did not assert the actual layout mode. This PR adds the missing responsive behavior and records that desktop/laptop checks must verify left/right TOC placement, not just absence of overlap.
