### PR TITLE
Apply const Cloudflare Access via SOPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ public/
 **/.terraform/
 *.tfstate
 *.tfstate.*
+!secrets/cloudflare-access.tfstate.enc.json
 tfplan
 *.tfplan
 *.tfplan.*

--- a/.legion/tasks/const-access-sops-apply/docs/pr-body.md
+++ b/.legion/tasks/const-access-sops-apply/docs/pr-body.md
@@ -1,0 +1,16 @@
+## Summary
+
+- Added SOPS-backed Cloudflare Access env/state handling for the `/const` Terraform stack.
+- Applied the Access application/policy with a final single-email include rule shape.
+- Saved Terraform state only as encrypted SOPS JSON and removed plaintext state/plan/log artifacts.
+
+## Verification
+
+- SOPS env/state encryption checks passed without printing decrypted values.
+- Terraform fmt/init/validate/plan/apply completed; plan scope was limited to the Access application and policy for `/const`, `/const/`, and `/const/*`.
+- Post-apply plan was no-op, anonymous `/const/` returned an Access challenge HTTP 302, and review-change passed.
+
+## Safety
+
+- No secret values, private identifiers, raw plan/apply logs, redirect URLs, or plaintext Terraform state are included.
+- No DNS, Pages, Workers, whole-domain protection, Access groups, IdP groups, or service tokens were added.

--- a/.legion/tasks/const-access-sops-apply/docs/report-walkthrough.md
+++ b/.legion/tasks/const-access-sops-apply/docs/report-walkthrough.md
@@ -1,0 +1,64 @@
+# Report Walkthrough: Const Access SOPS Apply
+
+**Task**: `const-access-sops-apply`  
+**Mode**: implementation  
+**Date**: 2026-06-11  
+**Delivery status**: Ready for reviewer walkthrough. `docs/test-report.md` and `docs/review-change.md` both record PASS outcomes.
+
+## Evidence used
+
+- `.legion/tasks/const-access-sops-apply/docs/test-report.md`
+- `.legion/tasks/const-access-sops-apply/docs/review-change.md`
+- `.legion/tasks/const-access-sops-apply/docs/rfc.md`
+- `.legion/tasks/const-access-sops-apply/docs/review-rfc.md`
+- `.legion/tasks/const-access-sops-apply/log.md`
+- Scaffold/runbook files referenced by those reports: `.sops.yaml`, `.gitignore`, `shell.nix`, `secrets/cloudflare-access.enc.env`, `secrets/cloudflare-access.tfstate.enc.json`, and `infra/cloudflare-access/`
+
+No decrypted secret values, private identity values, raw Terraform state, plan output, apply output, Access redirect URL, or Cloudflare resource IDs are reproduced here.
+
+## What changed for reviewers
+
+This delivery moved the already-scaffolded Cloudflare Access Terraform stack through SOPS-backed real apply and verification for the `/const` path. The implementation remained limited to the Access application/policy workflow and its secret/state handling; it did not add DNS, Pages, Workers, whole-domain protection, Access groups, IdP groups, or service tokens.
+
+## SOPS env and state setup
+
+- The task added a repo SOPS setup for encrypted files under `secrets/`, including the Terraform env file and encrypted JSON state path.
+- `secrets/cloudflare-access.enc.env` is the private input source for `CLOUDFLARE_API_TOKEN` and required `TF_VAR_*` values. Verification checked that it is encrypted, decryptable, and usable through `sops exec-env` without printing values.
+- Terraform state is durably preserved as SOPS-encrypted JSON at `secrets/cloudflare-access.tfstate.enc.json`.
+- Plaintext Terraform state, backups, plan files, and temporary apply/plan logs were removed after verification. `.gitignore` keeps plaintext Terraform artifacts ignored and allow-lists only the encrypted state file.
+
+## Final Access include rule shape
+
+- The final policy include boundary is one email rule using Cloudflare provider v5 object syntax.
+- Shape only: `[{"email":{"email":"<private-email>"}}]` in the SOPS env / equivalent Terraform object form.
+- Earlier `group.email` input was rejected by provider validation because group rules require a group id. The rule was corrected to the intended single-email boundary without printing the actual email value.
+
+## Terraform plan and apply scope
+
+- Terraform `fmt`, `init -backend=false`, `validate`, and plan generation passed using the SOPS-provided environment.
+- Plan scope assertions showed exactly two creates:
+  - `cloudflare_zero_trust_access_application.const`
+  - `cloudflare_zero_trust_access_policy.const`
+- Destination coverage was asserted as exactly:
+  - `/const`
+  - `/const/`
+  - `/const/*`
+- No DNS, Pages, Workers, whole-domain, or unrelated Cloudflare resources were included in the plan/apply scope.
+- Apply completed successfully from the reviewed plan. Apply output was redirected to a temporary log and deleted to avoid retaining private identifiers or resource details in task evidence.
+
+## Post-apply verification
+
+- The encrypted state was restored temporarily for a post-apply Terraform plan.
+- `terraform plan -detailed-exitcode` returned exit code `0`, recorded as a post-apply no-op plan.
+- An anonymous HTTP request to `/const/` returned `302`, recorded as an Access challenge. The hostname and redirect URL were not printed.
+- After verification, plaintext state and temporary logs were removed again.
+
+## Delivery review result
+
+`docs/review-change.md` records **PASS** with no blocking findings. The review covered secret leakage risk, SOPS env/state encryption, Terraform state cleanup, Cloudflare Access resource scope, apply evidence, post-apply no-op evidence, and the anonymous Access challenge.
+
+## Residual notes
+
+- Raw plan/apply/state evidence is intentionally summarized rather than embedded, because those artifacts can contain sensitive identifiers.
+- The stack still uses local state with a SOPS-encrypted tracked copy; there is no remote locking, so only one operator should run this Terraform stack at a time.
+- The encrypted state remains sensitive and should stay limited to intended SOPS recipients.

--- a/.legion/tasks/const-access-sops-apply/docs/review-change.md
+++ b/.legion/tasks/const-access-sops-apply/docs/review-change.md
@@ -1,0 +1,55 @@
+# Review Change: Const Access SOPS Apply
+
+**Task**: `const-access-sops-apply`  
+**Date**: 2026-06-11  
+**Status**: PASS
+
+## Findings
+
+No blocking findings.
+
+## Review Scope
+
+- Secret leakage risk for SOPS env, encrypted Terraform state, Terraform plan/apply logs, and task docs.
+- SOPS config correctness for `secrets/*.enc.env` and `secrets/*.enc.json`.
+- Terraform state handling and cleanup of plaintext artifacts.
+- Cloudflare Access resource scope and `/const` path coverage.
+- Apply and post-apply verification evidence.
+
+## Evidence Reviewed
+
+- `.sops.yaml`
+- `secrets/cloudflare-access.enc.env`
+- `secrets/cloudflare-access.tfstate.enc.json`
+- `.gitignore`
+- `shell.nix`
+- `infra/cloudflare-access/*`
+- `.legion/tasks/const-access-sops-apply/docs/test-report.md`
+- `.legion/tasks/const-access-sops-apply/tasks.md`
+- `.legion/tasks/const-access-sops-apply/log.md`
+
+## Checks
+
+| Check | Result | Notes |
+|---|---|---|
+| Changed scope | PASS | Terraform declares only the intended Cloudflare Access application and policy resources. |
+| SOPS env/state encryption | PASS | `sops filestatus` reports encrypted for env and state; decrypt checks were redirected to `/dev/null`. |
+| Required private vars | PASS | Required vars exist and include rule shape is single email without printing values. |
+| State safety | PASS | Encrypted state exists; no plaintext `tfstate` or `tfplan` remains in `infra/cloudflare-access`. |
+| Ignore rules | PASS | Plaintext state, state backups, plan files, `terraform.tfvars`, and auto tfvars are ignored; encrypted state is allow-listed. |
+| Apply evidence | PASS | Test report records scoped plan, successful apply, encrypted state save, post-apply no-op plan, and anonymous Access challenge HTTP 302. |
+| Terraform validation | PASS | `terraform fmt -check` and `terraform validate` passed through `nix-shell`. |
+
+## Resolved Follow-up
+
+The reviewer noted that `infra/cloudflare-access/terraform.tfvars.example` still showed an Access group example after the final decision moved to one email include rule. The example was updated to `email.email`, and Terraform formatting/validation was rerun successfully.
+
+## Residual Risks
+
+- Apply evidence is intentionally summary-only because raw plan/apply logs and state can contain sensitive identifiers.
+- Local encrypted state has no remote locking; only one operator should run this stack at a time.
+- The encrypted state remains sensitive and should stay limited to intended SOPS recipients.
+
+## Conclusion
+
+The change is ready for delivery review and PR lifecycle. No required follow-up remains before delivery.

--- a/.legion/tasks/const-access-sops-apply/docs/review-rfc.md
+++ b/.legion/tasks/const-access-sops-apply/docs/review-rfc.md
@@ -1,0 +1,50 @@
+# RFC Review: SOPS-managed Cloudflare Access Terraform inputs
+
+**Task**: `const-access-sops-apply`  
+**Review phase**: `review-rfc`  
+**Date**: 2026-06-11  
+**Decision**: PASS
+
+## Scope reviewed
+
+- `.legion/tasks/const-access-sops-apply/plan.md`
+- `.legion/tasks/const-access-sops-apply/docs/rfc.md`
+- `infra/cloudflare-access/` Terraform shape
+- `secrets/api_key.enc` SOPS recipient metadata
+- `shell.nix`
+- `.gitignore`
+
+No private key material was read or required for this review.
+
+## Blocking findings
+
+None.
+
+## Findings
+
+1. **SOPS `.enc.env` design is safe and executable.**
+   - `sops exec-env secrets/cloudflare-access.enc.env` is an appropriate way to inject `CLOUDFLARE_API_TOKEN` and `TF_VAR_*` without creating plaintext tfvars.
+   - Required secret fields and no-chat-secret handling are explicit.
+   - Implementation should keep scaffold values as placeholders only and avoid printing decrypted values during validation.
+
+2. **`.sops.yaml` recipient choice is reasonable.**
+   - The RFC uses the existing/default SSH public recipient already visible in `secrets/api_key.enc` metadata.
+   - This stores only public recipient material in repo config and does not require reading or exposing the private key.
+
+3. **Cloudflare token scope is least-privilege for the planned Terraform resources.**
+   - The RFC limits the token to Access Apps/Policies Read + Write/Edit on the target account/zone as exposed by the Cloudflare UI.
+   - It explicitly rejects Global API Key/full admin and unrelated DNS, Workers, Pages, or broad account permissions.
+   - The 403 fallback is correctly bounded: identify the missing Access Apps/Policies scope rather than broadening permissions.
+
+4. **Terraform state strategy avoids post-apply state loss without committing plaintext state.**
+   - SOPS-encrypted local state under `secrets/cloudflare-access.tfstate.enc.json` is acceptable for this task and survives worktree cleanup.
+   - The RFC requires `.gitignore` allow-listing for the encrypted state, encrypted pre-apply checkpoints, decryptability verification, and removal of plaintext state/backups before commit.
+   - Non-blocking implementation caution: write encrypted state via a temporary output file and move it into place only after successful encryption/decrypt verification, to avoid clobbering the previous encrypted state on command failure.
+
+5. **Apply gate is clear enough to prevent unsafe apply.**
+   - `apply` is blocked until RFC review passes, scaffold exists, the user locally fills SOPS secrets, required variables are present without printing values, Terraform plan succeeds, the plan only touches intended Access app/policy resources for `/const`, and the user explicitly accepts the plan.
+   - The RFC correctly instructs that users must not paste token/account/zone/identity values into chat.
+
+## Decision
+
+PASS. The RFC can proceed to **Scaffold Implementation**. Remaining open items are implementation/user-gate details, not design blockers.

--- a/.legion/tasks/const-access-sops-apply/docs/rfc.md
+++ b/.legion/tasks/const-access-sops-apply/docs/rfc.md
@@ -1,0 +1,343 @@
+# RFC: SOPS-managed Cloudflare Access Terraform inputs
+
+**Task**: `const-access-sops-apply`  
+**Status**: Proposed for `review-rfc`  
+**Date**: 2026-06-11  
+**Scope**: Design only. Do not run Terraform `apply` in this phase.
+
+## 1. Context
+
+`infra/cloudflare-access/` already contains Terraform resources for one Cloudflare Zero Trust Access policy and one self-hosted Access application. The provider is configured to read `CLOUDFLARE_API_TOKEN` from the environment, and variables such as `account_id`, `zone_id`, `site_hostname`, and `access_policy_include` are declared in Terraform.
+
+Current repo observations:
+
+- `shell.nix` includes `sops` and `age`; Terraform itself is not declared there.
+- `secrets/api_key.enc` is already SOPS-encrypted with the SSH public recipient from `~/.ssh/id_ed25519.pub`.
+- `.gitignore` already ignores plaintext Terraform state/plan/tfvars patterns (`*.tfstate`, `*.tfstate.*`, `*.tfplan*`, `terraform.tfvars`, `*.auto.tfvars`). If an encrypted state file is committed as `secrets/cloudflare-access.tfstate.enc.json`, implementation must add a specific allow-list exception for that encrypted file.
+
+Public recipient found from `~/.ssh/id_ed25519.pub`:
+
+```text
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKrC5k/qhfJUVkMG0Fr+RKEIf1VV9Q6eSWLcnP+NXiFR c.one@thrimbda.com
+```
+
+Only the public key was read. The private key must not be read, copied, logged, or committed.
+
+## 2. Goals and non-goals
+
+### Goals
+
+- Define `.sops.yaml` creation rules for repo-local encrypted secret/state files.
+- Define a SOPS-managed env file for Terraform and the Cloudflare provider.
+- Tell the user how to create a least-privilege Cloudflare API token without pasting it into chat.
+- Define a state strategy that survives worktree cleanup without committing plaintext state.
+- Define apply gates, verification, and rollback boundaries.
+
+### Non-goals
+
+- No Cloudflare token, account ID, zone ID, email, group ID, IdP ID, service token ID, team domain, plaintext tfvars, plaintext state, or plan artifact should be written into chat or unencrypted files.
+- Do not broaden Terraform scope beyond `infra/cloudflare-access/`.
+- Do not create DNS, Pages, Workers, Access Groups, IdPs, or service tokens in this task unless a later reviewed RFC explicitly expands scope.
+- Do not run `terraform apply` until the user confirms the SOPS secret is filled and the Terraform plan is acceptable.
+- Do not run `terraform destroy` without explicit user confirmation.
+
+## 3. `.sops.yaml` design
+
+Recommended implementation:
+
+```yaml
+creation_rules:
+  # New encrypted env and JSON secret/state files.
+  - path_regex: ^secrets/.*\.enc\.(env|json)$
+    age: >-
+      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKrC5k/qhfJUVkMG0Fr+RKEIf1VV9Q6eSWLcnP+NXiFR c.one@thrimbda.com
+
+  # Existing repo convention, for example secrets/api_key.enc.
+  - path_regex: ^secrets/.*\.enc$
+    age: >-
+      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKrC5k/qhfJUVkMG0Fr+RKEIf1VV9Q6eSWLcnP+NXiFR c.one@thrimbda.com
+```
+
+Rationale:
+
+- Uses the default local SSH public key as requested and matches the recipient already visible in existing SOPS metadata.
+- Restricts automatic encryption rules to the `secrets/` namespace and `.enc.*` / `.enc` naming, so accidental plaintext files do not become silently accepted.
+- Keeps public recipient material in config only; the private key remains local and outside the repo.
+
+## 4. Secret env file design
+
+Recommended file: `secrets/cloudflare-access.enc.env`
+
+The user should create/edit it locally with SOPS, for example:
+
+```sh
+sops secrets/cloudflare-access.enc.env
+```
+
+Template shape, with placeholders only:
+
+```dotenv
+CLOUDFLARE_API_TOKEN=REPLACE_WITH_CLOUDFLARE_API_TOKEN
+
+TF_VAR_account_id=REPLACE_WITH_CLOUDFLARE_ACCOUNT_ID
+TF_VAR_zone_id=REPLACE_WITH_CLOUDFLARE_ZONE_ID
+TF_VAR_site_hostname=REPLACE_WITH_TARGET_HOSTNAME
+
+# Optional if keeping Terraform defaults:
+TF_VAR_const_path=const
+TF_VAR_application_name=const
+TF_VAR_policy_name=Allow const access
+TF_VAR_policy_decision=allow
+TF_VAR_session_duration=24h
+
+# Provider v5 Access rule object syntax. Use private values only.
+# Example shape only; replace with the user's actual minimal identity rule.
+TF_VAR_access_policy_include=[{"email":{"email":"REPLACE_WITH_EMAIL"}}]
+
+# Omit these variables to use Terraform defaults, or set to Terraform null/list syntax if needed.
+# TF_VAR_access_policy_require=null
+# TF_VAR_access_policy_exclude=null
+```
+
+Required values to fill locally:
+
+- `CLOUDFLARE_API_TOKEN`: custom Cloudflare API token, never Global API Key.
+- `TF_VAR_account_id`: target Cloudflare account ID.
+- `TF_VAR_zone_id`: target Cloudflare zone ID for the public site.
+- `TF_VAR_site_hostname`: target hostname only, no scheme and no path.
+- `TF_VAR_access_policy_include`: minimal Access identity include rule in Cloudflare provider v5 object syntax.
+
+Optional values, only if the defaults are not acceptable:
+
+- `TF_VAR_const_path`: expected to remain the `const` path unless deliberately changed and reviewed.
+- `TF_VAR_application_name`, `TF_VAR_policy_name`, `TF_VAR_policy_decision`, `TF_VAR_session_duration`.
+- `TF_VAR_access_policy_require`, `TF_VAR_access_policy_exclude`.
+
+Identity rule guidance:
+
+- Prefer a narrow single-email rule when the intended private access boundary is exactly one user.
+- A narrow Access group or IdP group rule remains acceptable only if that is the user's intended private access boundary.
+- Avoid broad rules such as everyone/all users unless explicitly reviewed.
+- Do not paste actual emails, group IDs, IdP IDs, service token IDs, or team domains into chat or docs.
+
+### Why `.enc.env` instead of JSON
+
+Use `.enc.env` because `sops exec-env` can inject `CLOUDFLARE_API_TOKEN` and `TF_VAR_*` directly into the Terraform process. JSON would require either a conversion step, a generated `terraform.tfvars`, a shell export script, or extra parsing with `jq`/templates. Those conversions create more places for plaintext to leak and make complex variable handling harder to audit. The only structured value needed here, `TF_VAR_access_policy_include`, can still be represented as a Terraform/JSON expression string inside the env file.
+
+## 5. Cloudflare API token design
+
+Web check performed on 2026-06-11:
+
+- Cloudflare's API token permissions reference lists `Access: Apps and Policies Read` and write-level names as `Access: Apps and Policies Write` / dashboard-style `Edit`, with descriptions for read/write access to Access applications and policies: <https://developers.cloudflare.com/fundamentals/api/reference/permissions/>
+- Cloudflare's token creation docs state that token policies bind permission groups to scoped resources and that permission names can be cosmetic; resource scoping is account/zone specific: <https://developers.cloudflare.com/fundamentals/api/how-to/create-via-api/>
+- Cloudflare API permission groups expose scopes such as account and account-zone resources: <https://developers.cloudflare.com/api/resources/user/subresources/tokens/subresources/permission_groups/>
+- Terraform provider docs for `cloudflare_zero_trust_access_application` and `cloudflare_zero_trust_access_policy` confirm this config is managing Access applications/policies with account/zone identifiers: <https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_application> and <https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_policy>
+
+Recommended user-facing token request steps:
+
+1. Open Cloudflare Dashboard.
+2. Go to **My Profile → API Tokens → Create Token → Create Custom Token**.
+3. Name it narrowly, for example `terraform-const-access`.
+4. Add account-scoped Access app/policy permissions for only the target account:
+   - `Access: Apps and Policies Read`
+   - `Access: Apps and Policies Write` or `Access: Apps and Policies Edit` if the UI uses `Edit`.
+5. Add zone-scoped Access app/policy permissions for only the target zone if the UI exposes Access Apps/Policies as a zone permission:
+   - `Access: Apps and Policies Read`
+   - `Access: Apps and Policies Write` / `Edit`
+6. Resource restrictions:
+   - Account resources: include only the target account.
+   - Zone resources: include only the target zone.
+   - Do not use all accounts/all zones unless Cloudflare UI cannot express the target restriction; if so, stop and record the limitation before continuing.
+7. Do not add unrelated permissions such as DNS Write, Zone Settings Write, Workers, Pages, or broad account admin permissions.
+8. If the UI has split permissions instead of the combined name, choose the narrow equivalent read/write permissions for both Access Apps and Access Policies only.
+9. Optional hardening: set token expiration and source IP restrictions if the user's operating environment supports it.
+10. Copy the token once and paste it only into `sops secrets/cloudflare-access.enc.env`, never into chat.
+
+Notes for naming drift:
+
+- Cloudflare docs and UI may show `Write` or `Edit` for the same write-level capability. Choose the write/edit entry whose description says it grants write access to Cloudflare Access applications and policies.
+- Prefer permission descriptions and resource scopes over cosmetic permission group names if the UI wording differs.
+- If Terraform `plan` returns 403 with the above permissions, do not immediately broaden to full admin. First identify whether the failing endpoint is account-scoped or zone-scoped and add only the missing Access Apps/Policies read/write permission for that scope.
+
+## 6. Terraform state strategy
+
+Current Terraform has no backend block, so Terraform will use local state under `infra/cloudflare-access/`. Worktree cleanup would lose the only state copy unless the task preserves it.
+
+### Option A — SOPS-encrypted local state in `secrets/` (recommended)
+
+Store the authoritative Terraform state as `secrets/cloudflare-access.tfstate.enc.json` encrypted by SOPS. Decrypt it only into `infra/cloudflare-access/terraform.tfstate` immediately before `plan/apply`; re-encrypt immediately after; remove plaintext state and backups from the worktree before commit.
+
+Pros:
+
+- Fits existing repo SOPS pattern and requested SSH recipient.
+- Survives worktree cleanup and PR lifecycle without committing plaintext state.
+- Avoids new remote backend credentials or Terraform Cloud setup.
+- Keeps reviewable operational state history as encrypted data.
+
+Cons / mitigations:
+
+- No remote locking; only one operator should run this Terraform stack at a time.
+- Encrypted state still contains sensitive environment metadata and must be treated as secret.
+- Existing `.gitignore` ignores `*.tfstate.*`; implementation must add `!secrets/*.tfstate.enc.json` if the encrypted state is meant to be committed.
+
+Recommended command shape:
+
+```sh
+# Before plan/apply: restore state if an encrypted state already exists.
+if [ -f secrets/cloudflare-access.tfstate.enc.json ]; then
+  sops -d --input-type json --output-type json \
+    --output infra/cloudflare-access/terraform.tfstate \
+    secrets/cloudflare-access.tfstate.enc.json
+  chmod 600 infra/cloudflare-access/terraform.tfstate
+fi
+
+# Run Terraform only with SOPS-provided environment.
+sops exec-env secrets/cloudflare-access.enc.env \
+  'terraform -chdir=infra/cloudflare-access init'
+sops exec-env secrets/cloudflare-access.enc.env \
+  'terraform -chdir=infra/cloudflare-access validate'
+sops exec-env secrets/cloudflare-access.enc.env \
+  'terraform -chdir=infra/cloudflare-access plan'
+
+# After an accepted apply, encrypt the resulting state before cleanup/commit.
+sops --encrypt --input-type json --output-type json \
+  --filename-override secrets/cloudflare-access.tfstate.enc.json \
+  infra/cloudflare-access/terraform.tfstate \
+  > secrets/cloudflare-access.tfstate.enc.json
+
+# Verify the encrypted state is decryptable without printing it.
+sops -d --input-type json --output-type json \
+  secrets/cloudflare-access.tfstate.enc.json >/dev/null
+
+# Remove plaintext state artifacts from the worktree.
+rm -f infra/cloudflare-access/terraform.tfstate \
+      infra/cloudflare-access/terraform.tfstate.backup
+```
+
+During implementation, prefer exact commands that avoid writing plaintext under `secrets/` even briefly. Do not commit plaintext state, plaintext state backups, or binary plan files.
+
+Before apply, if an encrypted state already exists, make an encrypted pre-apply copy such as `secrets/cloudflare-access.tfstate.pre-YYYYMMDDHHMMSS.enc.json` or otherwise record a recoverable encrypted checkpoint. Do not create a plaintext backup checkpoint.
+
+### Option B — Remote backend / Terraform Cloud
+
+Add a backend with remote state and locking.
+
+Pros:
+
+- Better state durability and locking.
+- Avoids committing any state artifact to the repo.
+
+Cons:
+
+- Requires selecting and provisioning a backend, credentials, access policy, and migration plan.
+- Expands task scope beyond applying the already merged Cloudflare Access config.
+- Adds another secret and operational dependency before the first apply.
+
+This is a good future hardening option but is too much coordination for this task.
+
+### Option C — Local unencrypted state outside the repo
+
+Keep `terraform.tfstate` only on the operator machine, possibly outside the worktree.
+
+Pros:
+
+- Minimal process and no backend setup.
+
+Cons:
+
+- Easy to lose during worktree cleanup or machine changes.
+- Not reproducible for later PR lifecycle or maintenance.
+- Violates the task requirement that state handling be explicit and durable.
+
+Not recommended.
+
+### State decision
+
+Use **Option A: SOPS-encrypted local state in `secrets/cloudflare-access.tfstate.enc.json`**, plus a `.gitignore` exception for that encrypted file. This keeps the current no-backend Terraform config while preventing loss of the only state copy.
+
+## 7. Apply gate and execution sequence
+
+No `terraform apply` is allowed until all gates are true:
+
+1. `review-rfc` passes or explicitly approves a revised design.
+2. `.sops.yaml` and `secrets/cloudflare-access.enc.env` are implemented.
+3. User confirms they filled the SOPS env locally. They must not paste secret values into chat.
+4. `sops exec-env` can prove required variables are present without printing values.
+5. Terraform `fmt`, `init`, `validate`, and `plan` succeed.
+6. The plan shows only the intended Cloudflare Access application/policy changes for the target hostname and `const` path coverage.
+7. User explicitly accepts the plan.
+
+Only after those gates should apply run:
+
+```sh
+sops exec-env secrets/cloudflare-access.enc.env \
+  'terraform -chdir=infra/cloudflare-access apply'
+```
+
+If using a saved plan file, it must be outside the repo or ignored, treated as sensitive, and deleted before commit. Prefer interactive review of `terraform plan` output unless a saved plan is necessary.
+
+## 8. Verification plan
+
+### Secret handling
+
+- `sops -d secrets/cloudflare-access.enc.env >/dev/null` succeeds without printing decrypted values in logs.
+- `sops exec-env secrets/cloudflare-access.enc.env 'sh -c "test -n \"$CLOUDFLARE_API_TOKEN\" && test -n \"$TF_VAR_account_id\" && test -n \"$TF_VAR_zone_id\" && test -n \"$TF_VAR_site_hostname\" && test -n \"$TF_VAR_access_policy_include\""'` succeeds.
+- Token verification may call Cloudflare's token verify endpoint, but must not print the token.
+
+### Terraform
+
+- `terraform -chdir=infra/cloudflare-access fmt -check`.
+- `sops exec-env ... 'terraform -chdir=infra/cloudflare-access init'`.
+- `sops exec-env ... 'terraform -chdir=infra/cloudflare-access validate'`.
+- `sops exec-env ... 'terraform -chdir=infra/cloudflare-access plan'`.
+- Confirm the plan affects only:
+  - `cloudflare_zero_trust_access_policy.const`
+  - `cloudflare_zero_trust_access_application.const`
+- Confirm destination coverage remains exactly the target hostname with:
+  - `/const`
+  - `/const/`
+  - `/const/*`
+- Confirm there are no DNS, Pages, Workers, whole-domain, or unrelated Cloudflare changes.
+
+### After apply
+
+- Terraform apply exits successfully.
+- Outputs show only non-secret metadata and expected destination URIs.
+- Cloudflare dashboard/API shows the Access application and policy attached as planned.
+- Access path check:
+  - unauthenticated request/browser visit to the protected `const` path should be intercepted by Cloudflare Access according to the selected identity policy;
+  - a non-protected page on the same site should remain reachable as before;
+  - a permitted identity should be able to complete Access authentication, if the user can test it.
+- Encrypt the final Terraform state, verify it decrypts, then remove plaintext state and backup files.
+- Check for leaks before commit:
+  - no `terraform.tfstate`, `terraform.tfstate.backup`, `tfplan`, `.tfplan`, `terraform.tfvars`, or unencrypted env files in `git status`;
+  - no token/account/zone/identity values in diffs, logs, docs, or helper output;
+  - only encrypted secret/state files may contain sensitive values.
+
+## 9. Rollback plan
+
+Rollback must be bounded and state-aware.
+
+- If Terraform fails before apply: no Cloudflare changes should exist; fix token permissions, variable syntax, or state restoration, then re-run plan.
+- If plan is unacceptable: stop. Do not apply. Adjust config or secret values only after review.
+- If apply succeeds but Access behavior is wrong:
+  1. Preserve the post-apply state by encrypting it immediately.
+  2. Prefer a corrective Terraform change/apply that narrows or fixes only the Access application/policy.
+  3. If urgent user access is blocked, the user may manually disable or adjust only the affected Access application/policy in Cloudflare Dashboard; the next Terraform step must reconcile/import/update state before further applies.
+  4. Do not run `terraform destroy` or delete Access resources unless the user explicitly confirms that destructive rollback is desired.
+- If state is corrupted or lost: stop; do not apply. Restore from the latest encrypted state checkpoint or import the live Access resources into Terraform state, then re-plan.
+
+## 10. Open items for review-rfc
+
+- Confirm whether the Cloudflare UI exposes combined `Access: Apps and Policies` permissions at both account and zone scopes for this account, or split `Access: Apps` / `Access: Policies` permissions.
+- Confirm whether the implementation should add Terraform to `shell.nix` or rely on an already available Terraform binary.
+- Confirm `.gitignore` exception for `secrets/cloudflare-access.tfstate.enc.json` if encrypted state will be committed.
+- Confirm the user's intended `access_policy_include` rule shape before apply, without exposing actual private identifiers in chat.
+
+## 11. Decision summary
+
+- Use `.sops.yaml` with the default SSH public recipient from `~/.ssh/id_ed25519.pub`.
+- Use `secrets/cloudflare-access.enc.env` for direct `sops exec-env` injection of `CLOUDFLARE_API_TOKEN` and `TF_VAR_*`.
+- Request a custom Cloudflare API token scoped to the target account/zone with only Access Apps/Policies Read and Write/Edit permissions.
+- Preserve Terraform state as SOPS-encrypted JSON in `secrets/cloudflare-access.tfstate.enc.json`; never commit plaintext state or plan files.
+- Gate `apply` on user-confirmed SOPS secret completion and an acceptable Terraform plan.

--- a/.legion/tasks/const-access-sops-apply/docs/test-report.md
+++ b/.legion/tasks/const-access-sops-apply/docs/test-report.md
@@ -1,0 +1,50 @@
+# Test Report: SOPS Apply Verification
+
+**Task**: `const-access-sops-apply`  
+**Phase**: scaffold verification plus **Phase 5 - Apply & Verification**  
+**Date**: 2026-06-11  
+**Result**: PASS. Terraform apply completed, encrypted state was saved, post-apply plan was no-op, and anonymous `/const/` access returned an Access challenge.
+
+## Verification basis
+
+Read before validation:
+
+- `.legion/tasks/const-access-sops-apply/plan.md`
+- `.legion/tasks/const-access-sops-apply/docs/rfc.md`
+- `.legion/tasks/const-access-sops-apply/docs/review-rfc.md`
+- current scaffold files: `.sops.yaml`, `secrets/cloudflare-access.enc.env`, `.gitignore`, `shell.nix`, `infra/cloudflare-access/README.md`, and Terraform files under `infra/cloudflare-access/`
+- previous `docs/test-report.md`
+
+The report keeps secret-bearing values out of logs and task docs. Commands that could print Cloudflare IDs, email, redirect URLs, resource IDs, or state content were redirected, summarized, or asserted via `jq` without value output.
+
+## Checks
+
+| Check | Command / Method | Result | Evidence / Notes |
+|---|---|---|---|
+| SOPS env is encrypted | `sops filestatus secrets/cloudflare-access.enc.env` | PASS | Returned `{"encrypted":true}`. The file contains SOPS `ENC[...]` values and SOPS metadata, not plaintext Cloudflare values. |
+| SOPS env decrypts without printing plaintext | `sops -d secrets/cloudflare-access.enc.env >/dev/null` | PASS | Command succeeded with decrypted output redirected to `/dev/null`; no secret values were printed. |
+| Required variables present via `exec-env` | `sops exec-env secrets/cloudflare-access.enc.env 'sh -eu -c "test -n required vars"'` | PASS | Checked `CLOUDFLARE_API_TOKEN`, `TF_VAR_account_id`, `TF_VAR_zone_id`, `TF_VAR_site_hostname`, and `TF_VAR_access_policy_include` for non-empty presence only; values were not printed. This proves the scaffold has all required keys, not that the user has supplied final real values. |
+| `.sops.yaml` creation rule matches `.enc.env` | `sops --encrypt --filename-override secrets/cloudflare-access.enc.env --input-type dotenv --output-type dotenv /dev/stdin >/dev/null <<< 'CLOUDFLARE_API_TOKEN=PLACEHOLDER'` | PASS | Encryption succeeded using the repo `.sops.yaml` rule for `^secrets/.*\.enc\.(env|json)$`. This uses only the public recipient in config; no private key was read, copied, or printed. |
+| Terraform artifact ignore rules | `git check-ignore -v --non-matching -- ...` | PASS | Plaintext state, state backups, plan files, `terraform.tfvars`, and `*.auto.tfvars` are ignored. `terraform.tfvars.example` remains unignored. `!secrets/cloudflare-access.tfstate.enc.json` allow-lists the encrypted state path. |
+| README token/apply/state guidance | Manual review of `infra/cloudflare-access/README.md` | PASS | README gives least-privilege token guidance, instructs editing only through SOPS, runs Terraform through `sops exec-env`, gates apply on plan/user approval, documents encrypted state restore/save, and forbids committing plaintext state/plan/tfvars/secrets. No real token/account/zone/email/group/team values found. |
+| `shell.nix` includes Terraform | Manual review of `shell.nix` | PASS | `terraform` is present in `packages`. |
+| Terraform fmt/init/validate via Nix | `nix-shell --run 'terraform -chdir=infra/cloudflare-access fmt -check && terraform -chdir=infra/cloudflare-access init -backend=false && terraform -chdir=infra/cloudflare-access validate'` | PASS | Terraform initialized successfully and reported `Success! The configuration is valid.` `init` used `-backend=false`; no `plan` or `apply` was run. |
+| Changed-file sensitive-value scan | Python static scan over `git diff --name-only` plus untracked files for obvious Cloudflare token/global-key/account-zone-id/email/identity UUID patterns, allow-listing SOPS `ENC[...]`, placeholders, and the SSH public recipient comment | PASS | Output: `STATIC_SECRET_SCAN=PASS`. Scanned changed files were `.gitignore`, `shell.nix`, task docs, `.sops.yaml`, `infra/cloudflare-access/README.md`, and `secrets/cloudflare-access.enc.env`. |
+| User secret gate after fill | Per-variable `sops exec-env` checks | PASS | Confirmed required vars were non-empty and not placeholders. Values were not printed. Initial gate caught missing/placeholder `TF_VAR_zone_id`; after user updated it, the gate passed. |
+| Include rule shape correction | `sops --decrypt --extract '["TF_VAR_access_policy_include"]' ... | jq` for key-only inspection, then `sops set --value-stdin` | PASS | Terraform provider v5 rejected the mistaken `group.email` shape because `group.id` is required. After user clarified the desired boundary is one email, the encrypted env was converted to `email.email` shape. Only key names were printed; the email value was not printed. |
+| Terraform plan generation | `terraform fmt -check`; `sops exec-env ... 'terraform -chdir=infra/cloudflare-access init -backend=false'`; `validate`; `plan -out=tfplan -no-color >/dev/null` | PASS | Plan file generated locally and was not printed. |
+| Plan scope gate | `terraform show -json tfplan | jq` assertions | PASS | Plan resource changes were exactly `cloudflare_zero_trust_access_application.const` create and `cloudflare_zero_trust_access_policy.const` create. Additional assertions confirmed destination coverage is exactly `/const`, `/const/`, and `/const/*`. |
+| Terraform apply | `sops exec-env ... 'terraform -chdir=infra/cloudflare-access apply -auto-approve -no-color tfplan >/tmp/opencode/cloudflare-access-apply.log 2>&1'` | PASS | Apply completed. Output was redirected to a temporary log and then deleted to avoid retaining resource IDs or private details in task evidence. |
+| Encrypted state save | `sops --encrypt --input-type json --output-type json --filename-override secrets/cloudflare-access.tfstate.enc.json --output <tmp> infra/cloudflare-access/terraform.tfstate`; `sops -d --input-type json --output-type json <tmp> >/dev/null`; move into `secrets/cloudflare-access.tfstate.enc.json` | PASS | Durable state copy exists only as SOPS-encrypted JSON in `secrets/cloudflare-access.tfstate.enc.json`. Plaintext state and backup were removed after verification. |
+| Post-apply no-op plan | Restore encrypted state temporarily, run `sops exec-env ... 'terraform -chdir=infra/cloudflare-access plan -detailed-exitcode -no-color >/tmp/opencode/cloudflare-access-postapply-plan.log 2>&1'`, then remove plaintext state and log | PASS | Exit code `0`, recorded as `post-apply-plan-noop`. |
+| Anonymous Access challenge | `sops exec-env ... curl -sS -o /dev/null -w '%{http_code}' 'https://$TF_VAR_site_hostname/const/'` | PASS | Returned `access-challenge-http-302`. Redirect URL and hostname were not printed. |
+
+## Non-actions / gates
+
+- Did not print or request any real Cloudflare token, account ID, zone ID, email, group ID, IdP/service-token ID, team domain, or private identity rule.
+- Did not print Terraform plan content, Terraform state content, apply output, Access redirect URL, resource IDs, or decrypted secret values.
+- Did not create or modify DNS, Pages, Workers, whole-domain protection, Access groups, IdP groups, or service tokens.
+
+## Current state
+
+Apply verification is PASS. `/const/` is protected by Cloudflare Access according to anonymous HTTP 302 challenge behavior. Terraform state has been encrypted to `secrets/cloudflare-access.tfstate.enc.json`; local plaintext state, backup, tfplan, and temporary apply/plan logs were removed.

--- a/.legion/tasks/const-access-sops-apply/log.md
+++ b/.legion/tasks/const-access-sops-apply/log.md
@@ -1,0 +1,59 @@
+# Const Access SOPS Apply - 日志
+
+## 会话进展 (2026-06-11)
+
+### 已完成
+- 通过 `legion-workflow` 入口门进入新任务 brainstorm。
+- 读取现有 `secrets/`、`shell.nix`、`infra/cloudflare-access/variables.tf`、`terraform.tfvars.example` 和上一任务 plan。
+- 确认仓库已有 SOPS encrypted 文件 `secrets/api_key.enc`，现有 shell 使用 `sops -d secrets/api_key.enc`。
+- 用户明确允许创建 `.sops.yaml`，并使用默认 `~/.ssh/id_ed25519.pub` 对应的 SSH recipient。
+- 建立任务契约 `const-access-sops-apply`。
+- 完成 `spec-rfc` 设计并写入 `.legion/tasks/const-access-sops-apply/docs/rfc.md`。
+- Web 确认 Cloudflare 当前 token 权限命名围绕 `Access: Apps and Policies Read` 与 `Write`/`Edit`，并记录 UI 命名漂移处理方式。
+- RFC 推荐使用 SOPS 加密保存 Terraform state：`secrets/cloudflare-access.tfstate.enc.json`，且不提交明文 state/plan/tfvars。
+- 完成 `review-rfc`：`docs/review-rfc.md` 结论 PASS，无 blocking findings，可进入 scaffold implementation。
+- 完成 Phase 3 Scaffold Implementation：新增 `.sops.yaml`、SOPS encrypted env scaffold、encrypted state `.gitignore` allow-list、Cloudflare Access Terraform README，并在 `shell.nix` 加入 `terraform`。
+- 验证 scaffold：SOPS env 可解密且未打印明文值；`.sops.yaml` 可被 SOPS 用于匹配目标文件；Terraform `fmt -check`/`init -backend=false`/`validate` 在 Nix shell 中通过。详见 `docs/test-report.md`。
+- 完成 `verify-change` scaffold 复核：确认 encrypted env/required vars、`.sops.yaml` creation rule、Terraform artifact `.gitignore`、README token/apply/state 指引、`shell.nix` Terraform、Nix shell Terraform fmt/init/validate、changed-file secret scan 均 PASS；未执行 Terraform plan/apply。详见 `docs/test-report.md`。
+- 用户确认已填好 `secrets/cloudflare-access.enc.env` 后，先执行 SOPS gate；发现 `TF_VAR_zone_id` 仍为空或 placeholder，未运行 plan/apply，并要求用户补齐。
+- 用户补齐 zone id 后重新通过 required-env gate；首次 Terraform plan 因 include rule 使用 `group.email` 失败，provider v5 schema 要求 `group.id`。按用户确认的意图将 encrypted env 内 `TF_VAR_access_policy_include` 从 `group.email` 转换为单个 `email.email` rule，未输出邮箱值。
+- 更新 Terraform 变量说明、README 和 RFC 示例，默认示例改为单个 email include rule。
+- Terraform `fmt -check`、`init -backend=false`、`validate`、`plan -out=tfplan` 通过；plan scope gate 只包含 `cloudflare_zero_trust_access_application.const` 和 `cloudflare_zero_trust_access_policy.const` 的 create，并确认 `/const`、`/const/`、`/const/*` 覆盖。
+- 执行 Terraform apply，输出重定向到临时日志避免泄漏资源 ID；apply 后将 local state 加密保存为 `secrets/cloudflare-access.tfstate.enc.json`，并删除明文 state、backup、tfplan 和临时 apply log。
+- Post-apply 验证通过：恢复 encrypted state 临时运行 plan 得到 no-op；匿名请求 `/const/` 返回 HTTP 302 Access challenge。验证后再次删除明文 state 和临时日志。
+- 完成 `review-change`：PASS，无 blocking findings；review 提出的 `terraform.tfvars.example` 仍偏向 group 示例的 follow-up 已修正为单 email 示例，并重新通过 Terraform fmt/validate。
+- 完成 `report-walkthrough`：生成 `docs/report-walkthrough.md` 和 `docs/pr-body.md`，不包含 secret、私有标识、raw plan/apply log、redirect URL 或 Terraform state。
+- 完成 `legion-wiki` writeback：新增 `wiki/tasks/const-access-sops-apply.md`，更新 index、patterns、wiki log，并把 SOPS-backed Terraform apply 模式提升为 reusable pattern。
+
+### 进行中
+- Phase 7 - PR Lifecycle：准备执行 final scan、commit、push、PR、merge、cleanup、刷新主工作区。
+
+### 阻塞/待定
+- 无当前阻塞。
+
+---
+
+## 关键决策
+| 决策 | 原因 | 替代方案 | 日期 |
+|---|---|---|---|
+| 使用 `secrets/cloudflare-access.enc.env` | `sops exec-env` 可以直接注入 `CLOUDFLARE_API_TOKEN` 与 `TF_VAR_*`，避免生成明文 tfvars | `.enc.json` 后再转换 env | 2026-06-11 |
+| 新增 `.sops.yaml` 并使用默认 SSH key recipient | 用户明确允许，且现有 encrypted secret 也使用 SSH recipient | 每次手写 recipient 参数 | 2026-06-11 |
+| apply 前必须解决 state 策略 | 当前 Terraform local state 若随 worktree 删除会丢失唯一状态副本 | 直接 apply 后清理 worktree | 2026-06-11 |
+| 推荐 SOPS 加密保存 Terraform state | 既避免引入新 remote backend，又能随 PR lifecycle 保存状态且不提交明文 | Terraform Cloud/remote backend；本机 unencrypted state | 2026-06-11 |
+| 使用单个 email include rule | 用户明确只需要一个 email，不需要 group；Cloudflare provider v5 的 group rule 要求 `group.id` | Access group/IdP group rule | 2026-06-11 |
+| Cloudflare token 最小权限聚焦 Access Apps/Policies Read + Write/Edit | Terraform 只管理 Access app/policy，应限制到目标 account/zone，避免 DNS/Workers/Pages 等无关权限 | Full admin token 或全账号/全 zone token | 2026-06-11 |
+
+---
+
+## 快速交接
+**下次继续从这里开始：**
+1. Terraform apply 已完成；encrypted state 保存在 `secrets/cloudflare-access.tfstate.enc.json`。
+2. Delivery review、walkthrough 和 wiki writeback 已完成；继续 commit/push/PR lifecycle。
+3. 如需再 plan/apply，必须先从 encrypted state 临时恢复 `infra/cloudflare-access/terraform.tfstate`，完成后重新清理明文 state。
+
+**注意事项：**
+- 不要让用户把真实 token 贴到聊天里；应让用户在本地用 `sops secrets/cloudflare-access.enc.env` 填写。
+- 不要提交或保留明文 `terraform.tfstate`、state backup、tfplan、apply log、token/account/zone/email/team 信息。
+
+---
+*Updated: 2026-06-11*

--- a/.legion/tasks/const-access-sops-apply/plan.md
+++ b/.legion/tasks/const-access-sops-apply/plan.md
@@ -1,0 +1,69 @@
+# Const Access SOPS Apply
+
+## 目标
+为 `infra/cloudflare-access/` 建立 SOPS 管理的 Cloudflare/Terraform 私有变量输入，指导用户申请最小权限 Cloudflare API token，并在用户完成 secret 填写后执行 Terraform `plan/apply` 让 `/const/` 真正受 Cloudflare Access 保护，最后通过 Legion Git/PR lifecycle 提交变更。
+
+## 问题陈述
+上一任务已经合并了 `/const/` 站点入口和 Terraform Cloudflare Access 配置，但没有执行 `terraform apply`，因此线上 Cloudflare Access 尚未生效。现在需要把真实 Cloudflare token、account/zone id、hostname 和 Access policy 身份规则放入 SOPS 加密文件，并用该加密输入驱动 Terraform apply。
+
+这项工作触及真实凭证、生产访问控制和 Terraform 状态。必须避免把明文 secret、local tfvars、tfstate 或 plan 提交进仓库；必须在 apply 前明确 token 权限、目标 zone、允许访问规则和状态处理方式。
+
+## 验收标准
+- [ ] 新增 `.sops.yaml`，使用默认 `~/.ssh/id_ed25519.pub` 对应的 SSH recipient 加密 `secrets/*.enc.*`。
+- [ ] 新增 SOPS 管理的 Cloudflare Access env 文件，推荐命名为 `secrets/cloudflare-access.enc.env`，用于提供 `CLOUDFLARE_API_TOKEN` 和 `TF_VAR_*`。
+- [ ] 文档或 helper 明确说明用户需要申请的 Cloudflare API token 权限、申请路径和需要填入 SOPS secret 的变量。
+- [ ] 在用户填完 secret 并确认后，使用 `sops exec-env` 或等价方式运行 Terraform `plan` 和 `apply`，不落明文 secret 到仓库。
+- [ ] Terraform apply 后能够确认 Cloudflare Access resources 已创建/更新，且保护范围仍是 `/const`、`/const/`、`/const/*`。
+- [ ] Terraform state 处理方式被明确记录，不因 worktree cleanup 丢失唯一状态副本。
+- [ ] Legion 验证、review、walkthrough、wiki writeback 和 Git/PR lifecycle 完成。
+
+## 假设 / 约束 / 风险
+- **假设**: 用户本机默认 SSH key `~/.ssh/id_ed25519.pub` 可作为 SOPS age recipient；现有 `secrets/api_key.enc.json` 已使用同一类 SSH recipient。
+- **假设**: 目标 hostname 为 `0xc1.space`，目标 path 仍为 `const`。
+- **假设**: 用户会在本地通过 `sops secrets/cloudflare-access.enc.env` 填入真实 token 和 Terraform 变量，而不是把明文贴到聊天或提交到仓库。
+- **约束**: 不提交明文 token、account id、zone id、真实邮箱/组/IdP/service token、team domain、tfstate、tfplan 或 `terraform.tfvars`。
+- **约束**: 在用户确认 secret 已填完、目标账号/zone/policy 规则无误前，不执行 `terraform apply`。
+- **约束**: Terraform apply 只能针对 `infra/cloudflare-access/`，不得配置 DNS、Pages、Workers 或其他 Cloudflare 产品。
+- **风险**: API token 权限过大可能扩大凭证泄露影响；权限过小会导致 apply 失败。
+- **风险**: Access policy 身份规则填写错误会导致 `/const/` 无法访问、未受保护或允许范围过宽。
+- **风险**: 当前 Terraform 使用 local state；若不设计 state 保存/加密策略，apply 后状态可能随 worktree 删除而丢失。
+
+## 要点
+- **Secret format**: 使用 `.enc.env`，因为 `sops exec-env` 可以直接把解密结果注入 `CLOUDFLARE_API_TOKEN` 与 `TF_VAR_*` 环境变量。
+- **SOPS config**: 新增 `.sops.yaml`，让 `secrets/*.enc.env`、必要时 `secrets/*.enc.json` 走默认 SSH recipient 加密。
+- **Token scope**: Cloudflare token 最小权限以 Access apps/policies write/read 为核心，并限制到目标 account/zone。
+- **Apply gate**: 先交付 secret scaffold 和申请说明；用户完成 secret 后再恢复任务执行 plan/apply。
+- **State**: 设计阶段必须明确 state 是否仅保留本机、SOPS 加密保存，或改用后端；不得在未记录状态策略时清理 worktree。
+
+## 范围
+- `.sops.yaml` - SOPS creation rules。
+- `secrets/cloudflare-access.enc.env` - SOPS 加密的 Cloudflare/Terraform env secret。
+- `infra/cloudflare-access/` - 如有必要，增加 README/helper 说明 SOPS apply 流程；Terraform resource 本体只在需要适配 secret/env 输入时修改。
+- `.legion/tasks/const-access-sops-apply/**` - 本任务 contract、RFC、验证、review、walkthrough。
+- `.legion/wiki/**` - 收口写回可复用的 SOPS/Terraform apply 模式。
+
+## 非范围 (Non-goals)
+- 不在聊天、日志或未加密文件中保存真实 Cloudflare token、account id、zone id 或身份规则。
+- 不创建 Cloudflare DNS、Pages、Workers、IdP、Access Group 或 Service Token，除非 RFC 明确证明它们是 apply 必需项并通过 review。
+- 不扩大 Access 保护范围到整个域名或其他路径。
+- 不执行 `terraform destroy`，除非 apply 失败并且用户明确要求回滚。
+- 不把 Terraform state 明文提交到仓库。
+
+## 设计索引 (Design Index)
+> **Design Source of Truth**: `.legion/tasks/const-access-sops-apply/docs/rfc.md`（待生成）
+
+**摘要**:
+- 核心流程: 先设计 SOPS env、Cloudflare token 权限和 Terraform state 策略；实现 secret scaffold 和说明；用户填入 secret 后恢复任务运行 plan/apply；最后完成审查、PR 和 wiki writeback。
+- 验证策略: 验证 SOPS 可解密/exec-env、Terraform fmt/init/validate/plan/apply、Cloudflare Access path 和无明文 secret 泄漏。
+
+## 阶段概览
+1. **Phase 1 - RFC**: 明确 SOPS 文件格式、token 权限、secret 变量、state 策略、apply/rollback 步骤。
+2. **Phase 2 - RFC Review**: 对凭证边界、state、apply 风险和 Access policy 做安全审查。
+3. **Phase 3 - Scaffold Implementation**: 在 worktree 中新增 `.sops.yaml`、encrypted env scaffold 和 apply 文档/helper。
+4. **Phase 4 - User Token Gate**: 告知用户 token 申请方式，等待用户用 SOPS 填入真实 secret。
+5. **Phase 5 - Apply & Verification**: 用户确认后执行 Terraform plan/apply，并验证 Access 生效或记录阻塞/回滚。
+6. **Phase 6 - Delivery Review**: 安全 review、walkthrough、PR body。
+7. **Phase 7 - Wiki Writeback + PR Lifecycle**: 写回可复用模式并完成 commit/push/PR/merge/cleanup/refresh。
+
+---
+*Created: 2026-06-11 | Updated: 2026-06-11*

--- a/.legion/tasks/const-access-sops-apply/tasks.md
+++ b/.legion/tasks/const-access-sops-apply/tasks.md
@@ -1,0 +1,40 @@
+# Const Access SOPS Apply - 任务清单
+
+## 快速恢复
+**当前阶段**: Phase 7 - PR Lifecycle
+**当前检查项**: review-change PASS；walkthrough/PR body generated；wiki writeback complete；等待 commit/push/PR/merge/cleanup/refresh
+**进度**: 17/18 任务完成
+
+---
+
+## 阶段 1: RFC ✅ DONE
+- [x] 设计 `.sops.yaml` 和 `secrets/cloudflare-access.enc.env` 格式 | 验收: RFC 说明选择 `.enc.env` 的原因
+- [x] 明确 Cloudflare API token 最小权限和申请步骤 | 验收: RFC/说明可直接给用户执行
+- [x] 明确 Terraform state 策略 | 验收: RFC 不允许 apply 后丢失 state
+- [x] 写入 RFC | 验收: 包含 Options、Decision、Verification、Rollback
+
+## 阶段 2: RFC Review ✅ DONE
+- [x] 执行 `review-rfc` | 验收: review-rfc PASS 后才实现或要求用户填 secret
+
+## 阶段 3: Scaffold Implementation ✅ DONE
+- [x] 进入 `git-worktree-pr` envelope | 验收: 修改在隔离 worktree 中完成
+- [x] 新增 `.sops.yaml` | 验收: 使用默认 SSH recipient
+- [x] 新增 SOPS encrypted env scaffold | 验收: 文件可由 `sops -d` 解密为 env 格式
+- [x] 新增或更新 apply 文档/helper | 验收: 用户知道如何填 secret 和执行 plan/apply
+- [x] 执行 `verify-change` scaffold 验证 | 验收: SOPS/env/.sops.yaml/.gitignore/README/Terraform fmt-init-validate/静态 secret scan 均 PASS，未 plan/apply
+
+## 阶段 4: User Token Gate ✅ DONE
+- [x] 告知用户 token 申请方式和需要填入的 secret 字段 | 验收: 用户确认 secret 已填完；后续将 include rule 从误填的 `group.email` 转换为 `email.email`
+
+## 阶段 5: Apply & Verification ✅ DONE
+- [x] 使用 SOPS env 执行 Terraform plan | 验收: plan 只影响 `cloudflare_zero_trust_access_application.const` 和 `cloudflare_zero_trust_access_policy.const`
+- [x] 用户确认后执行 Terraform apply | 验收: apply 成功，state 加密保存到 `secrets/cloudflare-access.tfstate.enc.json`
+- [x] 验证 Cloudflare Access 保护生效 | 验收: post-apply plan no-op；匿名 `/const/` 请求返回 Access challenge HTTP 302
+
+## 阶段 6: Delivery Review ✅ DONE
+- [x] 执行 `review-change`，包含 secrets/infra 安全视角 | 验收: review-change PASS；无 blocking findings；`terraform.tfvars.example` follow-up 已修正
+- [x] 执行 `report-walkthrough` | 验收: walkthrough 和 PR body 已生成
+
+## 阶段 7: Wiki Writeback + PR Lifecycle ⏳ IN PROGRESS
+- [x] 执行 `legion-wiki` 收口 | 验收: wiki 记录 SOPS/Terraform apply 模式
+- [ ] Commit/push/PR/merge/cleanup/refresh | 验收: PR 终态完成，主工作区刷新

--- a/.legion/wiki/index.md
+++ b/.legion/wiki/index.md
@@ -3,6 +3,8 @@
 ## Current Durable Notes
 
 - `tasks/daily-log-split-design.md`: Daily log split architecture and viewport validation decisions.
+- `tasks/const-cloudflare-access.md`: `/const` route and Cloudflare Access Terraform scaffold.
+- `tasks/const-access-sops-apply.md`: SOPS-backed Cloudflare Access apply and encrypted Terraform state handling.
 - `tasks/daily-log-toc-implementation.md`: Daily archive TOC implementation and duplicate-date sequence rule.
 - `tasks/daily-toc-desktop-layout-fix.md`: Daily archive TOC breakpoint correction after production/demo mismatch.
 - `patterns.md`: Reusable theme and archive implementation conventions.
@@ -10,4 +12,4 @@
 
 ## Current Truth
 
-The blog is a Zola static archive with a deliberate terminal-paper visual language. Long daily-log pages should be split into atomic Markdown pages through static sections and pagination. Daily archive navigation should look like a document TOC, with infinite loading used only as progressive enhancement.
+The blog is a Zola static archive with a deliberate terminal-paper visual language. Long daily-log pages should be split into atomic Markdown pages through static sections and pagination. Daily archive navigation should look like a document TOC, with infinite loading used only as progressive enhancement. The `/const` path is protected by Cloudflare Access through Terraform, with Cloudflare/Terraform private inputs and local state managed through SOPS encrypted files.

--- a/.legion/wiki/log.md
+++ b/.legion/wiki/log.md
@@ -10,3 +10,8 @@
 - Updated daily-log maintenance backlog after TOC implementation.
 - Added task summary for `daily-toc-desktop-layout-fix`.
 - Promoted a daily archive responsive verification rule: desktop/laptop checks must assert left/right TOC placement, not just visual non-overlap.
+
+## 2026-06-11
+- Added task summary for `const-access-sops-apply`.
+- Promoted the SOPS-backed Terraform apply pattern: encrypted env inputs, temporary plaintext state only during operations, encrypted JSON state as durable copy, plan scope gate, and no raw secret-bearing evidence in docs.
+- Updated current truth to note `/const` is protected by Cloudflare Access with SOPS-managed private inputs/state.

--- a/.legion/wiki/patterns.md
+++ b/.legion/wiki/patterns.md
@@ -47,3 +47,18 @@ Theme changes should keep the current blog identity:
 ## Mobile Outline Default
 
 For article outline rails, mobile can default to collapsed when no stored user state exists. A stored per-page reader preference should override viewport defaults.
+
+## SOPS-Backed Terraform Apply
+
+For small sensitive Terraform stacks that do not use a remote backend:
+
+- keep private inputs in a SOPS encrypted env file
+- run Terraform through `sops exec-env` instead of writing plaintext tfvars
+- restore plaintext local state only for the duration of plan/apply/verification
+- save durable state as SOPS encrypted JSON
+- ignore plaintext state, backups, plan files, and tfvars
+- delete apply logs and plan logs if they may contain resource IDs or private identifiers
+- record only scoped summaries and pass/fail evidence in task docs
+- require a plan scope gate before apply
+
+For Cloudflare Access path protection, continue to assert exact, trailing slash, and wildcard descendant coverage for the intended path family.

--- a/.legion/wiki/tasks/const-access-sops-apply.md
+++ b/.legion/wiki/tasks/const-access-sops-apply.md
@@ -1,0 +1,40 @@
+# const-access-sops-apply
+
+## Metadata
+- `task-id`: `const-access-sops-apply`
+- `status`: `active`
+- `risk`: `high`
+- `schema-version`: `legion-wiki-current`
+- `historical`: `false`
+- `supersedes`: `const-cloudflare-access production rollout pending note`
+- `superseded-by`: `(none)`
+
+## Outcome Summary
+- Added repo SOPS creation rules for encrypted Cloudflare/Terraform env and state files under `secrets/`.
+- Added a SOPS encrypted env source for `CLOUDFLARE_API_TOKEN` and required `TF_VAR_*` inputs.
+- Applied the Cloudflare Access Terraform stack for `/const` after a scoped plan gate.
+- Final Access include boundary is a single email rule shape in provider v5 syntax, with the actual email kept only in SOPS encrypted env.
+- Saved Terraform local state as SOPS encrypted JSON at `secrets/cloudflare-access.tfstate.enc.json` and removed plaintext state, plan, and temporary logs.
+- Verified post-apply plan no-op and anonymous `/const/` HTTP 302 Access challenge.
+
+## Reusable Decisions
+- For small sensitive Terraform stacks without a remote backend, keep durable state as SOPS encrypted JSON and restore plaintext state only for the duration of plan/apply/verification.
+- Run Terraform with `sops exec-env` instead of generating plaintext tfvars when the private inputs can be represented as `TF_VAR_*` environment variables.
+- For Cloudflare provider v5 Access policy include rules, a single-email boundary uses `email.email`; `group` rules require a group id and should not be used for email-only allowlists.
+- Apply logs, raw plan output, state content, resource IDs, redirect URLs, and private identity values should stay out of task docs and PR descriptions.
+
+## Related Raw Sources
+- `plan`: `.legion/tasks/const-access-sops-apply/plan.md`
+- `log`: `.legion/tasks/const-access-sops-apply/log.md`
+- `tasks`: `.legion/tasks/const-access-sops-apply/tasks.md`
+- `rfc`: `.legion/tasks/const-access-sops-apply/docs/rfc.md`
+- `rfc-review`: `.legion/tasks/const-access-sops-apply/docs/review-rfc.md`
+- `test-report`: `.legion/tasks/const-access-sops-apply/docs/test-report.md`
+- `change-review`: `.legion/tasks/const-access-sops-apply/docs/review-change.md`
+- `report`: `.legion/tasks/const-access-sops-apply/docs/report-walkthrough.md`
+- `pr-body`: `.legion/tasks/const-access-sops-apply/docs/pr-body.md`
+
+## Notes
+- The encrypted state remains sensitive and should stay limited to intended SOPS recipients.
+- The stack still has no remote locking; only one operator should run it at a time.
+- If future work changes the Access policy boundary, re-run a plan scope gate and avoid printing private identity values.

--- a/.legion/wiki/tasks/const-cloudflare-access.md
+++ b/.legion/wiki/tasks/const-cloudflare-access.md
@@ -7,7 +7,7 @@
 - `schema-version`: `legion-wiki-current`
 - `historical`: `false`
 - `supersedes`: `(none)`
-- `superseded-by`: `(none)`
+- `superseded-by`: `const-access-sops-apply` for production rollout/state handling
 
 ## Outcome Summary
 - Added a new `const` site entry using existing Zola navigation conventions.
@@ -32,5 +32,5 @@
 - `pr-body`: `.legion/tasks/const-cloudflare-access/docs/pr-body.md`
 
 ## Notes
-- Production rollout still requires a private Terraform variable source and an environment owner to run apply outside this task.
-- If a matching Access app already exists, import or coordinate instead of creating a duplicate.
+- Production rollout and state handling were completed by `const-access-sops-apply`.
+- If a matching Access app already exists in future environments, import or coordinate instead of creating a duplicate.

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,10 @@
+creation_rules:
+  # New encrypted env and JSON secret/state files.
+  - path_regex: ^secrets/.*\.enc\.(env|json)$
+    age: >-
+      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKrC5k/qhfJUVkMG0Fr+RKEIf1VV9Q6eSWLcnP+NXiFR c.one@thrimbda.com
+
+  # Existing repo convention, for example secrets/api_key.enc.
+  - path_regex: ^secrets/.*\.enc$
+    age: >-
+      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKrC5k/qhfJUVkMG0Fr+RKEIf1VV9Q6eSWLcnP+NXiFR c.one@thrimbda.com

--- a/infra/cloudflare-access/README.md
+++ b/infra/cloudflare-access/README.md
@@ -1,0 +1,123 @@
+# Cloudflare Access Terraform runbook
+
+This directory manages only the Cloudflare Zero Trust Access application and policy for the `/const` path. Do not use it for DNS, Pages, Workers, or unrelated Cloudflare resources.
+
+## 1. Create a least-privilege Cloudflare API token
+
+In Cloudflare Dashboard, open **My Profile → API Tokens → Create Token → Create Custom Token**.
+
+Recommended token shape:
+
+- Name: `terraform-const-access` or similarly narrow.
+- Account scope: only the target account.
+- Zone scope: only the target zone for the site hostname.
+- Permissions: only Access Apps/Policies read plus write/edit permissions. Cloudflare UI wording may be `Access: Apps and Policies Read` and `Access: Apps and Policies Write` or `Edit`.
+- Do not grant Global API Key, full admin, DNS Write, Zone Settings Write, Workers, Pages, or all-account/all-zone access.
+- Optional hardening: token expiration and source IP restrictions if they fit the operating environment.
+
+Copy the token once and paste it only into the SOPS file below. Do **not** paste tokens, account IDs, zone IDs, identity rules, team domains, group IDs, or emails into chat, docs, shell history, or unencrypted files.
+
+## 2. Fill the SOPS env file
+
+Edit the encrypted dotenv scaffold from the repository root:
+
+```sh
+sops secrets/cloudflare-access.enc.env
+```
+
+Fill at least these variables inside the SOPS editor:
+
+- `CLOUDFLARE_API_TOKEN`
+- `TF_VAR_account_id`
+- `TF_VAR_zone_id`
+- `TF_VAR_site_hostname` — hostname only, no scheme and no path.
+- `TF_VAR_access_policy_include` — provider v5 Access include rule syntax, for example `[{"email":{"email":"REPLACE_WITH_EMAIL"}}]` with your private email value.
+
+Keep `TF_VAR_const_path=const` unless a separate reviewed change intentionally moves the protected path.
+
+Check that the file decrypts without printing values:
+
+```sh
+sops -d secrets/cloudflare-access.enc.env >/dev/null
+```
+
+## 3. Run Terraform through `sops exec-env`
+
+From the repository root, run Terraform with secrets injected only into the child process:
+
+If `terraform` is not already on `PATH`, enter `nix-shell` first; `shell.nix` includes Terraform for this workflow.
+
+```sh
+terraform -chdir=infra/cloudflare-access fmt -check
+sops exec-env secrets/cloudflare-access.enc.env 'terraform -chdir=infra/cloudflare-access init'
+sops exec-env secrets/cloudflare-access.enc.env 'terraform -chdir=infra/cloudflare-access validate'
+sops exec-env secrets/cloudflare-access.enc.env 'terraform -chdir=infra/cloudflare-access plan'
+```
+
+Review the plan before apply. It must touch only:
+
+- `cloudflare_zero_trust_access_policy.const`
+- `cloudflare_zero_trust_access_application.const`
+
+The destination coverage must remain the target hostname plus exactly:
+
+- `/const`
+- `/const/`
+- `/const/*`
+
+Do not continue if the plan includes DNS, Pages, Workers, whole-domain protection, unrelated resources, or unexpected identity rules.
+
+Only after the plan is acceptable and the operator/user explicitly approves the apply gate:
+
+```sh
+sops exec-env secrets/cloudflare-access.enc.env 'terraform -chdir=infra/cloudflare-access apply'
+```
+
+Do not run `terraform destroy` unless explicitly requested as a separate destructive rollback.
+
+## 4. Encrypted local state handling
+
+This stack intentionally uses local Terraform state, but the durable tracked copy is SOPS-encrypted:
+
+```text
+secrets/cloudflare-access.tfstate.enc.json
+```
+
+Before plan/apply, restore state if an encrypted state already exists:
+
+```sh
+if [ -f secrets/cloudflare-access.tfstate.enc.json ]; then
+  sops -d --input-type json --output-type json \
+    --output infra/cloudflare-access/terraform.tfstate \
+    secrets/cloudflare-access.tfstate.enc.json
+  chmod 600 infra/cloudflare-access/terraform.tfstate
+fi
+```
+
+After a successful apply, encrypt the resulting state through a temporary file, verify it, then move it into place:
+
+```sh
+tmp_state="$(mktemp /tmp/cloudflare-access.tfstate.enc.json.XXXXXX)"
+sops --encrypt --input-type json --output-type json \
+  --filename-override secrets/cloudflare-access.tfstate.enc.json \
+  --output "$tmp_state" \
+  infra/cloudflare-access/terraform.tfstate
+sops -d --input-type json --output-type json "$tmp_state" >/dev/null
+mv "$tmp_state" secrets/cloudflare-access.tfstate.enc.json
+rm -f infra/cloudflare-access/terraform.tfstate \
+      infra/cloudflare-access/terraform.tfstate.backup
+```
+
+Never commit plaintext `terraform.tfstate`, state backups, plan files, `terraform.tfvars`, `*.auto.tfvars`, or unencrypted env files. The `.gitignore` allow-list is only for the encrypted state file above.
+
+## 5. Apply gate
+
+Applying is allowed only after all of the following are true:
+
+1. The SOPS env file is filled locally and decrypts successfully without printing values.
+2. Required env variables are present via `sops exec-env`.
+3. `terraform fmt`, `init`, `validate`, and `plan` succeed.
+4. The plan is limited to the intended Access application/policy and `/const` path coverage.
+5. The operator/user explicitly accepts the reviewed plan.
+
+If any gate fails, stop and fix the narrow issue before retrying. Do not broaden Cloudflare token permissions beyond the missing Access Apps/Policies scope without review.

--- a/infra/cloudflare-access/terraform.tfvars.example
+++ b/infra/cloudflare-access/terraform.tfvars.example
@@ -14,12 +14,12 @@ site_hostname = "example.com"
 const_path = "const"
 
 # Provider v5 Access rule object syntax. Replace with private identity rules
-# outside the repository, for example an Access group, IdP group, service token,
-# or email rule using non-public values.
+# outside the repository. This example uses a single email rule; Access group,
+# IdP group, or service token rules are also possible when intentionally chosen.
 access_policy_include = [
   {
-    group = {
-      id = "REPLACE_WITH_ACCESS_GROUP_ID"
+    email = {
+      email = "REPLACE_WITH_EMAIL"
     }
   }
 ]

--- a/infra/cloudflare-access/variables.tf
+++ b/infra/cloudflare-access/variables.tf
@@ -55,7 +55,7 @@ variable "policy_decision" {
 }
 
 variable "access_policy_include" {
-  description = "Private Access include rules in Cloudflare provider v5 object syntax, for example [{ group = { id = \"REPLACE_WITH_ACCESS_GROUP_ID\" } }]. Do not commit real emails, domains, group IDs, IdP IDs, or service token IDs."
+  description = "Private Access include rules in Cloudflare provider v5 object syntax, for example [{ email = { email = \"REPLACE_WITH_EMAIL\" } }]. Do not commit real emails, domains, group IDs, IdP IDs, or service token IDs."
   type        = any
   sensitive   = true
 }

--- a/secrets/cloudflare-access.enc.env
+++ b/secrets/cloudflare-access.enc.env
@@ -1,0 +1,12 @@
+CLOUDFLARE_API_TOKEN=ENC[AES256_GCM,data:fIZOOG/5zy9zWMrThdRsloTq9lE1+WwNjYfpYU9iHk6ZozUIkzLl7w9Y7IrhVnBpOOArvHY=,iv:0UKMc9EdCuLTLUqEupi+kmXBLqYvfc6QhYBDBPyIvC4=,tag:1tEMUOWT6+w/nS7K+3HERQ==,type:str]
+TF_VAR_account_id=ENC[AES256_GCM,data:GNsY1fEFCRl8yNar+ooWB3nUyVe5/PeV/rnxA/DRqh4=,iv:ofCDzL8p/QmTgUV0chHqNNhOpbk9pWBxv3JEIy77kp4=,tag:6w0+kohPfx5j1id58RFXew==,type:str]
+TF_VAR_zone_id=ENC[AES256_GCM,data:P+EozvnTQC2pC1hHs4ZX5kEF0oANPP0byaI5389F1DA=,iv:X+ulPg+U+R/cgcSKY/8ozg5N2Dgd5Jpf5Jtb9Khi+JI=,tag:LXNVEvsaoNBv9qJT7QDLfg==,type:str]
+TF_VAR_site_hostname=ENC[AES256_GCM,data:SmWOT9SscdxBaQ==,iv:ugJKS4It7qS1N0h0py5C78Ax/JSBYfuekk3A32vWoUA=,tag:/TtlI8XmUeTIzYNrOM2JsQ==,type:str]
+TF_VAR_const_path=ENC[AES256_GCM,data:qOZIKiA=,iv:gMBdWeO6LUaXNvHrCZK4SaWQ2icW0Q8appinS7NVr1A=,tag:0sLjfTQ98pCfCx8PByLCJQ==,type:str]
+TF_VAR_access_policy_include=ENC[AES256_GCM,data:N8uZee2eDgNPvdI4b4zQEe51Jyz3RD6u5keVdxr18cG8M0u00vHzMuGpI7Q=,iv:N1cUnwhtYxeya2SmPFntx5DBu8YqLElHgBKTx8jnjsM=,tag:4gwun4RgegRvSC+Xpb/vwA==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNzaC1lZDI1NTE5IGo2M3pTdyBLRGRw\ncm9aMTg0UHlXWVJ1YlFHVHN5aUVNNDEvcFJRTXFDOURNNTZjR1gwCmo1eGFMQ010\nQlNTVUZyaHhlcjNzbTI5Rk5YbzhpWDU4Zy9tdW9zQW5MTUEKLS0tIFJZcXFEdStB\nRlVGOWlNRURhY3lPRWlKK0FxMWdFaEVEYnBCOWFreHBTNUEKaGTcZr3lB0olr00d\n6uS8XjTV/QNJo2qLm+rEXM3/p9zvo9M+SyVnpQoN6/1t2Nk8U6ebvMfJAHKf25nj\nWgTSbA==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKrC5k/qhfJUVkMG0Fr+RKEIf1VV9Q6eSWLcnP+NXiFR c.one@thrimbda.com
+sops_lastmodified=2026-06-11T09:14:47Z
+sops_mac=ENC[AES256_GCM,data:ewMYq2E8yVGoubEJdNAfEpb4v+cxlCOcrl0GISAwHj2J7oxXn5r8sLQPIzgGi+hNagMAmkJsleglRpxlfC5kqUuN7gvNoiNnN4CLtSIJCqqWVddnUGJhAsBA4sijHina+dMYb8y95tBXcsUD4wTXLTIqSPAQ4p0nqXa1bB+u1+k=,iv:s/3fUgwDOCwaj38/JdmVqW0/fhfXTC3/uS8wFdJeXxk=,tag:Q57UYCf36ucc+7Rn+C8Hxg==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.11.0

--- a/secrets/cloudflare-access.tfstate.enc.json
+++ b/secrets/cloudflare-access.tfstate.enc.json
@@ -1,0 +1,279 @@
+{
+	"version": "ENC[AES256_GCM,data:vw==,iv:uVBMOPnXacLoxe5TjMWXyQjbtXmhpRBwW6Etgm1DfcE=,tag:CHB2VTLU8+adZZ0cSD8eEA==,type:float]",
+	"terraform_version": "ENC[AES256_GCM,data:UB+S4six,iv:g27A8yq1QYCCBnm7M/SojozMzLQxsneCtzyqQkmXy4g=,tag:yoHb250wmjbE96WfLaSSjg==,type:str]",
+	"serial": "ENC[AES256_GCM,data:pQ==,iv:BzE4Qh/SIEheNqtg/5h4hbG14FGiTvKI5gfr9HMwrQU=,tag:CpZ4vjbzMCwLnfegGL3u7w==,type:float]",
+	"lineage": "ENC[AES256_GCM,data:5MxP0urQFlLuMB8fB5F2B+ESCWC07CzVw9CBpU12Ah7tLp6Q,iv:/hMrtIxdnvwyOiug0ljVWzA0MtaAQYJmDTAiF3TJAko=,tag:TAUVBvzWk4s6MMNpbuu2Iw==,type:str]",
+	"outputs": {
+		"const_access_application_id": {
+			"value": "ENC[AES256_GCM,data:8XBTBniXx7IeyhumYkkR/EvVfAnv1HWpFGDzyrsQoYFapBLZ,iv:+Iqk2QuaDwLjVsap2AnXZnyH/Jnay20pACcXyYk3zN8=,tag:8GndvtanK7l832d2LfiPLQ==,type:str]",
+			"type": "ENC[AES256_GCM,data:YV0P82MH,iv:zqr0zFMn1J61ulhWizgbvYlE/NJJ9qtJdg/GkUL3Ok4=,tag:RQuXaaJVfAcaRt7wQCv7zg==,type:str]"
+		},
+		"const_access_destination_uris": {
+			"value": [
+				"ENC[AES256_GCM,data:NOKhixuB6b2XwKwQuXLfgg==,iv:okZOQH0p7EQf4xn/54UAXsheYbXfPMCgOZHDa13EMEw=,tag:Wio8LM93hI5jVuh+XTaA+w==,type:str]",
+				"ENC[AES256_GCM,data:DCjZkHLBVmm0YAnwiRupQtE=,iv:nSH+9B3b4fuHJU8rZplVLC3X8TTSf3D5PIgWLVQoZnY=,tag:DDzMynnKGZtqPrbCGxFGgg==,type:str]",
+				"ENC[AES256_GCM,data:xGMExMB0KmPgfLBtsTHqbpR8,iv:ikdQUZFbbQa7KqwLJhsiKYqiAU7bg/df+ChFWwrP8ag=,tag:InaVQB/mK1AeeDBZLYAUXg==,type:str]"
+			],
+			"type": [
+				"ENC[AES256_GCM,data:AEXr/00=,iv:NdH5e/+jv0VfVsh4frqRUuqhjMOuLiPNe8ez9z1rhEM=,tag:NmsXlSQvppl++IM+trF2eg==,type:str]",
+				[
+					"ENC[AES256_GCM,data:SM3NPUFx,iv:pKmWHZ0CssqqnnvMp7LEok6iKXdLHG0XVk61itgOJlE=,tag:GFJuWJGraZFZOdtNxRi+Cg==,type:str]",
+					"ENC[AES256_GCM,data:S8o1HuO1,iv:okTk39LOAVLVnBQYP9t3rB3ypeCgAm5v24zuOGRfl98=,tag:QtBLwXsexMMGe5CfbAcRCA==,type:str]",
+					"ENC[AES256_GCM,data:Nut2uevq,iv:8esn1qURHdO84eZ9/n1qrpuVTxU6yQx7LqGP+ccnpOo=,tag:RlxFam/zuVMuePwQtJw95A==,type:str]"
+				]
+			]
+		},
+		"const_access_policy_id": {
+			"value": "ENC[AES256_GCM,data:Wc5fVOpIMCW3bpNbElcu6UtwA+pKPO6Wf3MrHydtTyIcxla+,iv:IxW0/MsLQlYqTtOAhkF/PIAYZTatRglFrTNU6861sKU=,tag:4s07Tf1rSIWZlkElDxWozg==,type:str]",
+			"type": "ENC[AES256_GCM,data:Q92oKTqb,iv:zeWXdVEEIOcG2TeoG0/rYhFx+85FCfeAQ/TotCnkxfo=,tag:G0/ghRjKqmkPVu2Yvwvwrg==,type:str]"
+		}
+	},
+	"resources": [
+		{
+			"mode": "ENC[AES256_GCM,data:in48SeC7yw==,iv:M2e4yPBwIMmHvYmMKS2tQYpXgQzkmZvmeIEG83myZYU=,tag:AK2IT8dwdH7Aw7noARGiYg==,type:str]",
+			"type": "ENC[AES256_GCM,data:in2xS9IyxG/FmZFXRR9DZ8NcEGOcE5fyvmYYGW7Eig0Iiz4ku0Jgtw==,iv:nbVPK5IfQj6n0uSVDUWdWvCAnVKAJNdfYBG26PoH4fU=,tag:9vEvXBqZeXP/YWh+nBEgqQ==,type:str]",
+			"name": "ENC[AES256_GCM,data:8/bzxl8=,iv:Rbxj1MjjsPpxOLHnCKveXGIb+Zc51TNVv7apiRXF/jc=,tag:hyNYQrQNT1EA9wYEyAMlnA==,type:str]",
+			"provider": "ENC[AES256_GCM,data:4ERVcPDjsoglzqAS8nKWf1AqwQn+nNRrD6lnmFPq7vlB0cptDMmZ7jVJQERu89yp6MdOUrs9Cg==,iv:HW+8mo8xmRY91tNCo/tAsLYnX5iqRugTOtC/xhr9LyQ=,tag:v87Yf6IFBH2xm0rKNzKdxw==,type:str]",
+			"instances": [
+				{
+					"schema_version": "ENC[AES256_GCM,data:/V3W,iv:xEj/wlXv1Pmd7/DByuM6Q8c0b7UPRKjgvonX6nqPXWU=,tag:yMdir87d+mSLGghVuHhjsg==,type:float]",
+					"attributes": {
+						"account_id": null,
+						"allow_authenticate_via_warp": null,
+						"allow_iframe": null,
+						"allowed_idps": null,
+						"app_launcher_logo_url": null,
+						"app_launcher_visible": "ENC[AES256_GCM,data:tQ1gOA==,iv:Qkfi/X1IZzNw+r+uX3yCShHAK9IhPiSumxyR2fiwnjA=,tag:Xc9EQlz+anhqTPhZnGF3oQ==,type:bool]",
+						"aud": "ENC[AES256_GCM,data:scvmrKs7v34MA8sb3ooPLPYyBEyMSDCKiA5CqAUhE9gkbWe9/6v/24iazTIUfsOyDb5m/AA5CDCj/9osHDGb4Q==,iv:jE416vkstazGuf0demHn4RmI9pfXatPOFrOPFceFKxQ=,tag:E6z9i/DZNgEkYXdJlb4Mzg==,type:str]",
+						"auto_redirect_to_identity": null,
+						"bg_color": null,
+						"cors_headers": null,
+						"custom_deny_message": null,
+						"custom_deny_url": null,
+						"custom_non_identity_deny_url": null,
+						"custom_pages": null,
+						"destinations": [
+							{
+								"cidr": null,
+								"hostname": null,
+								"l4_protocol": null,
+								"mcp_server_id": null,
+								"port_range": null,
+								"type": "ENC[AES256_GCM,data:EBHC/o18,iv:h4VG41Q2Sv+YHK+J1/PzV0PFfAUOnTyqj86jk+4M4Cg=,tag:gsgbOIrYkpdhvFOop63aQA==,type:str]",
+								"uri": "ENC[AES256_GCM,data:N27scR8HKJ3m9w2tdQi+Ww==,iv:Gcg58k0/idYpJgwhhttgVoDHlB07j8RtcDlF0ALP3dY=,tag:s2qBIqPQ+y7k/i1Lq85imA==,type:str]",
+								"vnet_id": null
+							},
+							{
+								"cidr": null,
+								"hostname": null,
+								"l4_protocol": null,
+								"mcp_server_id": null,
+								"port_range": null,
+								"type": "ENC[AES256_GCM,data:PPzSq0Dn,iv:S/KoCB1bzZEl0vfkcPf+5mHtjx4hxQWKrAiDSZPjS+8=,tag:bMxuTDXXEe5gj6c1iM0a4Q==,type:str]",
+								"uri": "ENC[AES256_GCM,data:IHo/zfbNtdzJZ81Op2D94p8=,iv:QUIuoAP8YIuxhXO4tuUg21vb83RtdXeCzJrLP6oZDpg=,tag:e/9oXd+x/D+sHA2sSDdrMA==,type:str]",
+								"vnet_id": null
+							},
+							{
+								"cidr": null,
+								"hostname": null,
+								"l4_protocol": null,
+								"mcp_server_id": null,
+								"port_range": null,
+								"type": "ENC[AES256_GCM,data:RKcCP8XE,iv:ESJMm7c1fokp+S1mlxRkkcTob6VHdsUeqHdoeRdj12Y=,tag:jUotOJMvjQ9fJf+Xkzu7zg==,type:str]",
+								"uri": "ENC[AES256_GCM,data:tFZFVRJLf9t7FAnSeiO//vhD,iv:IGmR2nfNoUIsIg3kx//J+7GvDMesUlBNLLvKyuScNCA=,tag:fGpQFRV6NvDgxtTXHiWEPw==,type:str]",
+								"vnet_id": null
+							}
+						],
+						"domain": "ENC[AES256_GCM,data:TChaqIDiaLL77dtFZVd7RQ==,iv:7XB4uKwnTnmh5uSab8Wivo1eLIRkTGougfZC4Pi/e+Q=,tag:CQZxkpXrZcroHRDtIZvvFA==,type:str]",
+						"enable_binding_cookie": null,
+						"footer_links": null,
+						"header_bg_color": null,
+						"http_only_cookie_attribute": "ENC[AES256_GCM,data:Nm0wGQ==,iv:phc4XH5TriS/qu9NVT/oDtihisa9TDLx6WIhj99NIuo=,tag:mZbFKAAvumGcfnyGXySNtw==,type:bool]",
+						"id": "ENC[AES256_GCM,data:J6HxnzSvkTEHzoEZCQqFOLubZC6o3zoA+m6WN9rjdwQcq8sC,iv:fcL5mx3PXpDRUzf1jPQ8lnP+6S5iYUQdO+Yn0CKhysM=,tag:A9urbuWh3QTBwXOD/u1QuA==,type:str]",
+						"landing_page_design": null,
+						"logo_url": null,
+						"mfa_config": null,
+						"name": "ENC[AES256_GCM,data:LaYN5Bw=,iv:cpvEHonAnhPNvfNK0HF5cO2XZvadh0dUBMzaT5uVm0w=,tag:4C7X8r48D/pPggXgulz2nA==,type:str]",
+						"oauth_configuration": null,
+						"options_preflight_bypass": null,
+						"path_cookie_attribute": null,
+						"policies": [
+							{
+								"connection_rules": null,
+								"decision": null,
+								"exclude": null,
+								"id": "ENC[AES256_GCM,data:tENqV4rJZdBoPMXiO3PMAbf4wufHuvKZs5FwzKLLpVECiJyU,iv:PnKEL1DfR3B17Kbd4/eHZ4jQ4a2VvqkEg9kGKKtxdJc=,tag:r1suByhJGnvau1MLVjaKtg==,type:str]",
+								"include": null,
+								"mfa_config": null,
+								"name": null,
+								"precedence": "ENC[AES256_GCM,data:5A==,iv:xu9ifHuOLyxkrffCxhDWzI+/hK0EnZhfSuxgAy3ksH4=,tag:gsw2Y3mSFYv1YQl8ZCDm0g==,type:float]",
+								"require": null
+							}
+						],
+						"read_service_tokens_from_header": null,
+						"saas_app": null,
+						"same_site_cookie_attribute": null,
+						"scim_config": null,
+						"self_hosted_domains": [
+							"ENC[AES256_GCM,data:xLk/z1glcJ96DmPy3cS+uw==,iv:4tA+NFqKA7cJnN4LXxTHPYKJS4hvSa4X+/hvYIxusrQ=,tag:tzB6is5kCY0bYJ98NVT6wg==,type:str]",
+							"ENC[AES256_GCM,data:Id3vTnfNv6u5UNbqQ8VU3AI=,iv:jhL3FEGOktOrmDAXmpcG0TxHgsz3b1KCC9mFAy+AOYs=,tag:oZo2w83JrOrzrgPfRyXXPQ==,type:str]",
+							"ENC[AES256_GCM,data:FqEt13UJQzyq8XxA6yz18k9h,iv:wI3Pt010nqGqU4cJgQ89yR9FMPFf5K3Vswe8B+8JzJM=,tag:pE//NlNZEzsiKaF01hDkBg==,type:str]"
+						],
+						"service_auth_401_redirect": null,
+						"session_duration": "ENC[AES256_GCM,data:Doig,iv:o5H61zsS4q+UZllTmYXrS7l2uxAbtZWOsdH1lESuSiI=,tag:W856FTRLMskoPKVA3VS32w==,type:str]",
+						"skip_app_launcher_login_page": null,
+						"skip_interstitial": null,
+						"tags": null,
+						"target_criteria": null,
+						"type": "ENC[AES256_GCM,data:l1jZ8BYqeVNkCjU=,iv:4DF5kBa0koyTsryGAAfEqsfzOacv/7v8Awu/ECo/ux8=,tag:tKeUgkVBq9L1VWFx3ejxlg==,type:str]",
+						"zone_id": "ENC[AES256_GCM,data:P/pAMqEZMEAXHN58eJ8qvZW2jR/j07RMBpdQ9G3NPao=,iv:m4ubY4gGYMJLXL6iWOCL0y2p8t/eYocLwn2UKgm9pcI=,tag:1cEn/RCabDsprs2LunNr3g==,type:str]"
+					},
+					"sensitive_attributes": [
+						[
+							{
+								"type": "ENC[AES256_GCM,data:vjUTSOk1mgM=,iv:Lx7mRKcicsqHjrL/4HmiaE4uxJRXt5GotHCMgzi5K+4=,tag:Q8xEcDIOWd5HEwBeTOpoVA==,type:str]",
+								"value": "ENC[AES256_GCM,data:voKUjeep1g==,iv:Sc9Q9WrMiYoSOvMOztKUDFU3ApD188uo9JSo0J2nNtc=,tag:E3NMOh/ssrRtkX1u8SFVpg==,type:str]"
+							}
+						]
+					],
+					"identity_schema_version": "ENC[AES256_GCM,data:mw==,iv:Yxx/hyGfunIRuS8FHGYjpwmf60jmT9dleVhnZt6y+sA=,tag:O/l9h0v+ZOJmEVgSHhC4+g==,type:float]",
+					"dependencies": [
+						"ENC[AES256_GCM,data:1Jtg/1UxtjyR+sWijZJz3DL4Dck0W1CGSmOVIy2WiX1/a7OpSwbMjt4=,iv:5gnFKMnLT/4jgl4XaJhflstf333TlGyDHB10SBC2n8w=,tag:2SSbTzYV4g1wAe83+p32mA==,type:str]"
+					]
+				}
+			]
+		},
+		{
+			"mode": "ENC[AES256_GCM,data:ohVxkZvKuw==,iv:mfks0aQh+sS2GDi16wzRVB9D4W5duSDSy0n0WfE0UNo=,tag:AZs5jqRDqmnRDd3riEWB5g==,type:str]",
+			"type": "ENC[AES256_GCM,data:hRwjQqrs631OObnf7w0j+CMGf88df1Qmqby7tMKRs39kkdM=,iv:sZOWBfiRsSk+kCipS0fB0WMcCe45fPgwCzODa/1a+WY=,tag:qAaoe+00RpfuP/FQosXxcg==,type:str]",
+			"name": "ENC[AES256_GCM,data:yxsTduI=,iv:qCiVv7l37GstuJFK23qNcmfcQ00dMS8nn140j8Tl+pk=,tag:D8e+MBG3qf2GdW+njCmPfw==,type:str]",
+			"provider": "ENC[AES256_GCM,data:Zln2LYruoah3fVfrZienvoaz7Igbxz1nnYSvtjcf4ySf4yVRBxHjF0WM9X8lqktHBB9FNFMMHw==,iv:+ssnKPB27DQb7HmbOWa1vJ4es3ljxHlV1WfYBVxK1Hk=,tag:Znv5FRPdhK8jiFQKnl34Tw==,type:str]",
+			"instances": [
+				{
+					"schema_version": "ENC[AES256_GCM,data:wJm5,iv:bwKcsPAxMrMSQY2Ybp4eCbgfteN0/1SHVXKMbf/MKaw=,tag:nlZSzg5pyau65k6Ol3pJCQ==,type:float]",
+					"attributes": {
+						"account_id": "ENC[AES256_GCM,data:BhCoplHAXXO7zZpf2ATEjZng1XOQoaSwBfmSPe7X6fQ=,iv:PQFmGJwZIIq6/QpVNzkXL2aBBW1bQ4zc7vna/sX8uoI=,tag:uOFfb6yYrI3vIonpKySkaA==,type:str]",
+						"approval_groups": null,
+						"approval_required": null,
+						"connection_rules": null,
+						"decision": "ENC[AES256_GCM,data:lWK4Kp8=,iv:lULovW3PLsoGaZYzN5kKDE4FXeSXCrKnMKnrrpFKJVs=,tag:+CnjEX7N9y8sUoYpkwe+og==,type:str]",
+						"exclude": null,
+						"id": "ENC[AES256_GCM,data:7xQbe6zdO44p3ah3ig04aK5cFxOvmoEeSL1TiyVvIOM2s5gu,iv:g2Tqmwu/D9hG4LA3SJ0fZBOPYhEHFmzwnJPgClETex4=,tag:EqPjNlBpMi3BeEowsiFHBA==,type:str]",
+						"include": [
+							{
+								"any_valid_service_token": null,
+								"auth_context": null,
+								"auth_method": null,
+								"azure_ad": null,
+								"certificate": null,
+								"common_name": null,
+								"device_posture": null,
+								"email": {
+									"email": "ENC[AES256_GCM,data:aCe77e4s/yZlqTXI/V9wIeiZGBk=,iv:Wo4AfV+dy7oTvaRsl/jtMrauLIcrZrALTcXVu6ZBiaU=,tag:ugl8SaN0rdDPfFbcQZfqaw==,type:str]"
+								},
+								"email_domain": null,
+								"email_list": null,
+								"everyone": null,
+								"external_evaluation": null,
+								"geo": null,
+								"github_organization": null,
+								"group": null,
+								"gsuite": null,
+								"ip": null,
+								"ip_list": null,
+								"linked_app_token": null,
+								"login_method": null,
+								"oidc": null,
+								"okta": null,
+								"saml": null,
+								"service_token": null,
+								"user_risk_score": null
+							}
+						],
+						"isolation_required": null,
+						"mfa_config": null,
+						"name": "ENC[AES256_GCM,data:eKsLyhbMKuybylt8w+TCe8zC,iv:ZnEdg3XD8nzaH3s9qm3e4E0Ns6D1SPP1pZbGsDQRWVQ=,tag:rmbhybHJ9xmUaV97EYqnlw==,type:str]",
+						"purpose_justification_prompt": null,
+						"purpose_justification_required": null,
+						"require": null,
+						"session_duration": "ENC[AES256_GCM,data:Tp/k,iv:Wn+Cwi4kx7IWhjnkxfQudhtdDtnJjawFMH9weeIaTGs=,tag:7keOZWSoZjrnW4XGkAlWwQ==,type:str]"
+					},
+					"sensitive_attributes": [
+						[
+							{
+								"type": "ENC[AES256_GCM,data:vnohMXq3ih8=,iv:aWaHQaqOlix5Cj4pihdQJnG13GaFoS3X1d1oJFHQzrA=,tag:xAYTF18drCSrLxntboo7/A==,type:str]",
+								"value": "ENC[AES256_GCM,data:JQ6AX0SeGtgy7A==,iv:aM7HbWOLjUnNrM7lrDRYAWwa7pjMLT5FIXAMLrrCfkg=,tag:djI3b+YXRKsWSgNc25/71g==,type:str]"
+							}
+						],
+						[
+							{
+								"type": "ENC[AES256_GCM,data:ztK1nNN8/Q0=,iv:ly42/cF8PIqTmOnd3UF7xlDmoSAz4cqxyosDWyQsyAo=,tag:PgW2ihZA2NksWazB6iKTdg==,type:str]",
+								"value": "ENC[AES256_GCM,data:PYDKvNewew==,iv:brOs8I1/FF1/U+o6ptKsSgBqDXcsLeNCgpdnxX2Pe6Y=,tag:MFqbEjlf0sfuWoYuwMdFuA==,type:str]"
+							}
+						],
+						[
+							{
+								"type": "ENC[AES256_GCM,data:xZDN3lXuibs=,iv:zUFE4bvX12KowxOQ7Fx28XijXAidWONEMJ52Fv+jp08=,tag:CyZy0v77mpbtmYrOoKSRpw==,type:str]",
+								"value": "ENC[AES256_GCM,data:WR60n1ya9Q==,iv:tt42EqoEuT4ejQ+lqaQc1dpqtL+ywnDYhYmkAcrIq8A=,tag:IA0N8i7ehUbJqwXS1z0g4A==,type:str]"
+							}
+						],
+						[
+							{
+								"type": "ENC[AES256_GCM,data:UbnOSA2dmH0=,iv:LN30VIoWcALhDqNOkd0vLFOBXvCYYddGkCvVDqIjTFQ=,tag:7QkAXTBbfWfsooFopazFrQ==,type:str]",
+								"value": "ENC[AES256_GCM,data:K+PwmCw++g==,iv:N1alZ5kUuMRKXxx8h5x9hAAL9eV/14xvgkoeCsljl6s=,tag:B+mKtnj8RGT17TSxGO4Jhg==,type:str]"
+							}
+						]
+					],
+					"identity_schema_version": "ENC[AES256_GCM,data:VQ==,iv:CU9XY86vqeDbwbNYcV66H7soj/M4AyDSNbuiUTAP6CQ=,tag:+U1JyXfVJvaTsi1v7eXZWg==,type:float]"
+				}
+			]
+		}
+	],
+	"check_results": [
+		{
+			"object_kind": "ENC[AES256_GCM,data:9DbL,iv:f15jkKG05wdtEwYRmgDEVbG5HCPn2NPm6Ix535/GDVw=,tag:nyi/Qj2pbWfrnzecS/MFOg==,type:str]",
+			"config_addr": "ENC[AES256_GCM,data:w5aSLaZ+BJCIuXgiEYptAcM=,iv:o+jpHv4gE6xy+2Ey9zXEqu0aKEj/qkOHMsabJbjyMrw=,tag:smHKFa27cHHzSiiZcBobkA==,type:str]",
+			"status": "ENC[AES256_GCM,data:hDpPXw==,iv:5IDPWyOigDqMIfC7ubXr3bSCqlIzVusVXrkYsMGzSLk=,tag:v1a6CREgKHiZwvzGK48ocw==,type:str]",
+			"objects": [
+				{
+					"object_addr": "ENC[AES256_GCM,data:1/ZyeZG/HLdhye9dCsRV+1w=,iv:PxUPmCEHiLH9UKAEhwANfn9VyMXbm8qWeioeweqfymA=,tag:RXxhQZEnnvdvX4FILbjCZQ==,type:str]",
+					"status": "ENC[AES256_GCM,data:6NmkGg==,iv:CzYDem5UlXgqyb1n519/JtvXOkk64jFykf8wNWMvTlw=,tag:FnRHLGvTqoLQCS5xhHLLAw==,type:str]"
+				}
+			]
+		},
+		{
+			"object_kind": "ENC[AES256_GCM,data:J2Rt,iv:+t0AAD3K4tkF5FvOVfeL9giqxpVkqxv3J+IHuiy25pA=,tag:TC+pDl4cBruz88BiLLsnxw==,type:str]",
+			"config_addr": "ENC[AES256_GCM,data:8GN1m1FBC9vsErzKnzQ=,iv:QLGYWF7BkBokzbyX6JOhAKVowQFlJ3292LxQ5yIkCl8=,tag:UNYoWhNudW3188ktKFJm0A==,type:str]",
+			"status": "ENC[AES256_GCM,data:I+oJkA==,iv:gcsj5SxLcKQqPCnGZBqYYwkL71MwCf3UW2K21VnO/q4=,tag:0PI4QPT22ANjpjOewK9GnA==,type:str]",
+			"objects": [
+				{
+					"object_addr": "ENC[AES256_GCM,data:mHD44ZZD/XeLjZBNuYw=,iv:hG3f0qsYUXGSV0fAuRojEhr2HNTON/E+EHHeE7O/Wns=,tag:8LTRkMsWlotyIh1KjHTkdw==,type:str]",
+					"status": "ENC[AES256_GCM,data:8XngdQ==,iv:jTa4YalPG/IeFZ1VnySG4hx8410HloXUaH3wpYJeSn0=,tag:66m58aIiOWlz8mXCbxYA+A==,type:str]"
+				}
+			]
+		},
+		{
+			"object_kind": "ENC[AES256_GCM,data:gQ4F,iv:UVqtk2btXf4fZ1GHsRFIwQS6ZAM6fUNwOZM/SGk3YfQ=,tag:SHGbFAIEDdd+qLZtA2WJuA==,type:str]",
+			"config_addr": "ENC[AES256_GCM,data:7QdNzRVPlg2FBinBtj/U4C+N+g==,iv:RVwg64agMJ765/hSPWr0RUh6ffc6ZzJPvNI2+74N2P0=,tag:vSkQ+a6sU+3d5G1UYysvTg==,type:str]",
+			"status": "ENC[AES256_GCM,data:0yVCxQ==,iv:+WFdfWLE3c2tc4ynM2KG3J6/sv7MMD0b5T1tSkHUe64=,tag:9NwTpIdvO9jB/hnbm2dklA==,type:str]",
+			"objects": [
+				{
+					"object_addr": "ENC[AES256_GCM,data:1qVLMxgW0phnRRyyTvK47DRSDQ==,iv:94B6/UZJR8YWZaHERJid71d0hFPT2iAM0VMMfCzvaRI=,tag:REwMu5fiSnaMjBQBiqyRwA==,type:str]",
+					"status": "ENC[AES256_GCM,data:NZlWSw==,iv:a+83wWGaq3qGXpJ0Xdah7RBsOZer5dCLtZg/Ew5C2ig=,tag:JYfW4Ge9OclTZGA0oYv92Q==,type:str]"
+				}
+			]
+		}
+	],
+	"sops": {
+		"age": [
+			{
+				"recipient": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKrC5k/qhfJUVkMG0Fr+RKEIf1VV9Q6eSWLcnP+NXiFR c.one@thrimbda.com",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNzaC1lZDI1NTE5IGo2M3pTdyBHa2pX\nU2xsTmNIT2Z6UmVneC9ObFdQd1ZJY3I3VmtZWC9DSTBSc1ZqakJJCjNDdEYvQ2d4\nb08ydkVVWkhramhSdWcrdjU2eXJVaHFrOG4vYkRVVGlnZ28KLS0tIDIxTHdHTEFq\nVnhPOERTZTdEdVlFTW1iV3ZiSDU5U0dPanZIaktReW5XdE0KFlY/j9bEJrjfGlEG\nm8lwkaY3BBjcroJLif9ZSLMDgT2gmDeH1JWwk5K8LKstgrG2JPxrEHLs0KT/J3JN\n7g2y3g==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2026-06-11T09:16:57Z",
+		"mac": "ENC[AES256_GCM,data:qBCdjp0klEjS52zYVf5B8kPCZJosCnCqgPwXkve4Ukz7f7uY2ZlfYenNhRAGj/G50ux+sU6qx7jnLXObj2iI82EMwf9yn2S2cav/u/oRAL9jNxU/CpfXBLK35Asr/9Izb8JXkTNNUT4ft0l8MBdCQO0JS0Y6iZ3oFBHBEEQmB8A=,iv:8Re0YJrly4kpelu7vrSCf4nOWJfMt122Uz0XR9+AdK0=,tag:9DLqANUgEI4IWFolVCgSBA==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.11.0"
+	}
+}

--- a/shell.nix
+++ b/shell.nix
@@ -4,6 +4,7 @@ mkShell {
     zola
     sops
     age
+    terraform
   ];
   shellHook = ''
     echo "🚀 0xc1 Blog Environment!"


### PR DESCRIPTION
## Summary

- Added SOPS-backed Cloudflare Access env/state handling for the `/const` Terraform stack.
- Applied the Access application/policy with a final single-email include rule shape.
- Saved Terraform state only as encrypted SOPS JSON and removed plaintext state/plan/log artifacts.

## Verification

- SOPS env/state encryption checks passed without printing decrypted values.
- Terraform fmt/init/validate/plan/apply completed; plan scope was limited to the Access application and policy for `/const`, `/const/`, and `/const/*`.
- Post-apply plan was no-op, anonymous `/const/` returned an Access challenge HTTP 302, and review-change passed.

## Safety

- No secret values, private identifiers, raw plan/apply logs, redirect URLs, or plaintext Terraform state are included.
- No DNS, Pages, Workers, whole-domain protection, Access groups, IdP groups, or service tokens were added.
