### PR TITLE
Implement daily TOC anchor plus interaction

### DIFF
--- a/.legion/tasks/daily-toc-anchor-plus/context.md
+++ b/.legion/tasks/daily-toc-anchor-plus/context.md
@@ -1,0 +1,22 @@
+# daily-toc-anchor-plus Context
+
+## 2026-06-12
+
+- User selected Version D from the HTML demos and requested production implementation using LegionMind.
+- Restored design context: site is a terminal-paper static archive; implementation must preserve text-first TOC styling.
+- Created worktree `legion/daily-toc-anchor-plus` from latest `origin/master` at `076bb47`.
+- Contract decision: primary TOC date links must scroll in the aggregate archive, while inline `+` links open standalone daily pages. Because the archive is paginated/infinite-loaded, implementation must resolve anchors that are not yet loaded.
+- Inspection found the existing production TOC links point directly to `item.path`, while aggregate entries already use stable `entry.slug` ids. The production change can stay narrow: add TOC anchor metadata, render primary `#slug` links plus a secondary `+`, and extend the existing infinite loader to resolve missing anchors.
+- Implemented Version D in production:
+  - `scripts/split-daily-logs.mjs` now emits `anchor` from each standalone path.
+  - `data/daily-toc.json` was updated mechanically with 202 anchors and no missing anchor values.
+  - `daily-archive.html` renders primary `#anchor` links and inline standalone `+` links, including duplicate same-day sequence rows.
+  - `style.css` keeps the terminal-paper TOC style, hides `+` until hover/focus on desktop, and shows it on mobile/touch.
+  - `script.js` reuses the existing infinite loader to load missing TOC targets before scrolling.
+- Verification passed:
+  - `git diff --check`
+  - `node --check themes/cone-scroll/static/js/script.js`
+  - `nix-shell --run 'zola build'`
+  - Playwright assertions for `/gcores-talks/`, `/diary/2020/`, and `/diary/2026/` at `393x852`, `1440x900`, and `2560x1440`
+  - Computer Use inspected Zen on the local `/gcores-talks/` page and confirmed the real desktop layout.
+- Wrote test report, change review, walkthrough, PR body, and wiki task summary.

--- a/.legion/tasks/daily-toc-anchor-plus/docs/pr-body.md
+++ b/.legion/tasks/daily-toc-anchor-plus/docs/pr-body.md
@@ -1,0 +1,20 @@
+## Summary
+
+- Implement Version D daily archive TOC behavior: date links scroll within the aggregate archive.
+- Add inline `+` links for opening standalone daily pages, including same-day sequence rows.
+- Extend infinite loading so TOC clicks can resolve dates that are not loaded yet.
+
+## Validation
+
+- `git diff --check`
+- `node --check themes/cone-scroll/static/js/script.js`
+- `nix-shell --run 'zola build'`
+- Playwright viewport and interaction assertions for `/gcores-talks/`, `/diary/2020/`, and `/diary/2026/` at:
+  - `393x852`
+  - `1440x900`
+  - `2560x1440`
+- Computer Use inspection in Zen at `http://127.0.0.1:1117/gcores-talks/`
+
+## Notes
+
+The split source files are not present in this worktree, so `data/daily-toc.json` was updated mechanically from existing `path` values. `scripts/split-daily-logs.mjs` now emits the same `anchor` field for future full regenerations.

--- a/.legion/tasks/daily-toc-anchor-plus/docs/report-walkthrough.md
+++ b/.legion/tasks/daily-toc-anchor-plus/docs/report-walkthrough.md
@@ -1,0 +1,33 @@
+# Report Walkthrough
+
+Mode: implementation.
+
+## Summary
+
+Implements the approved Version D daily archive TOC interaction. Dates now behave like a normal document TOC and locate entries in the aggregate archive. The inline `+` is the secondary action for opening a standalone daily page.
+
+## Delivery
+
+- Primary daily TOC links now render as `#entry-slug` anchors.
+- Inline `+` links open the existing standalone daily page URL.
+- Same-day duplicate entries each get their own sequence row and `+` link.
+- The existing infinite loader can load later paginated archive pages until a requested anchor appears.
+- Desktop keeps a quiet hover/focus `+`; mobile and touch keep `+` visible.
+
+## Evidence
+
+- Test report: `.legion/tasks/daily-toc-anchor-plus/docs/test-report.md`
+- Review: `.legion/tasks/daily-toc-anchor-plus/docs/review-change.md`
+
+## Verification Highlights
+
+- `zola build` passed.
+- `node --check themes/cone-scroll/static/js/script.js` passed.
+- Playwright passed for `/gcores-talks/`, `/diary/2020/`, and `/diary/2026/` at `393x852`, `1440x900`, and `2560x1440`.
+- Loaded TOC anchors scroll and focus their entry.
+- Unloaded TOC anchors trigger lazy loading and then scroll to the target.
+- Computer Use inspected the local Zen browser page and confirmed the real desktop layout.
+
+## Lifecycle
+
+This task is PR-backed. Completion requires commit, rebase, push, PR, checks, merge, cleanup, and main workspace refresh.

--- a/.legion/tasks/daily-toc-anchor-plus/docs/review-change.md
+++ b/.legion/tasks/daily-toc-anchor-plus/docs/review-change.md
@@ -1,0 +1,53 @@
+# Review Change: Daily TOC Anchor Plus
+
+## Decision
+
+PASS
+
+## Scope Review
+
+In scope:
+
+- Added durable TOC anchor metadata in `scripts/split-daily-logs.mjs` and `data/daily-toc.json`.
+- Updated `daily-archive.html` so primary TOC links point to aggregate article ids.
+- Added inline `+` standalone links for single-entry dates and same-day sequence rows.
+- Extended the existing infinite loader so TOC clicks can resolve entries that are not loaded yet.
+- Kept the terminal-paper TOC visual style.
+
+No out-of-scope redesign, URL migration, or article TOC behavior change was introduced.
+
+## Correctness Review
+
+No blocking findings.
+
+Evidence:
+
+- `git diff --check` passed.
+- `node --check themes/cone-scroll/static/js/script.js` passed.
+- `zola build` passed.
+- Playwright verified three archive pages at iPhone, 13-inch, and 27-inch viewports.
+- Playwright verified loaded-anchor scroll, unloaded-anchor lazy load, desktop hover `+`, and mobile visible `+`.
+
+## Maintainability Review
+
+No blocking findings.
+
+The anchor value is stored in the generated TOC data rather than recomputed in the template. This keeps the template presentational and makes future split regeneration deterministic.
+
+## Accessibility And Fallback Review
+
+No blocking findings.
+
+- Date entries remain plain links.
+- The `+` link has an `aria-label` that identifies the standalone daily page action.
+- Touch and narrow layouts do not depend on hover to expose standalone pages.
+- Entry articles are focusable after scripted navigation.
+- Existing pagination remains available without JavaScript.
+
+## Security Review
+
+No security trigger was introduced. This change does not touch authentication, secrets, permissions, sessions, or privileged data paths.
+
+## Non-Blocking Notes
+
+- The real browser visual check used Computer Use in Zen. Exact interaction assertions use Playwright because it can reliably control viewport and wait for lazy-loaded targets.

--- a/.legion/tasks/daily-toc-anchor-plus/docs/test-report.md
+++ b/.legion/tasks/daily-toc-anchor-plus/docs/test-report.md
@@ -1,0 +1,62 @@
+# Test Report: Daily TOC Anchor Plus
+
+## Summary
+
+Status: PASS
+
+Version D is implemented on `/gcores-talks/`, `/diary/2020/`, and `/diary/2026/`: the primary TOC link targets the aggregate page entry, while the inline `+` opens the standalone daily page.
+
+## Commands
+
+- `git diff --check`
+- `node --check themes/cone-scroll/static/js/script.js`
+- `nix-shell --run 'zola build'`
+- `nix-shell --run 'zola serve --interface 127.0.0.1 --port 1117 --base-url 127.0.0.1'`
+- Playwright assertions against `http://127.0.0.1:1117` for all three archive pages at `393x852`, `1440x900`, and `2560x1440`
+
+## Build Evidence
+
+`zola build` completed successfully with Zola 0.21.0 from `shell.nix`.
+
+Output summary:
+
+- Created 257 pages and 9 sections.
+- Internal anchor check completed.
+- No build errors.
+
+## Browser Matrix
+
+| Page | 393x852 iPhone | 1440x900 13-inch | 2560x1440 27-inch |
+| --- | --- | --- | --- |
+| `/gcores-talks/` | PASS | PASS | PASS |
+| `/diary/2020/` | PASS | PASS | PASS |
+| `/diary/2026/` | PASS | PASS | PASS |
+
+Assertions covered:
+
+- Primary TOC links start with `#` and use the aggregate entry anchor.
+- Inline `+` links keep the standalone daily URL.
+- Desktop layout uses left rail plus right feed with sticky TOC.
+- Desktop `+` opacity is `0` before hover and `1` after hover.
+- Mobile layout remains in-flow, and `+` is visible without hover.
+- Clicking a loaded TOC date updates the hash and focuses the matching entry.
+- Clicking an unloaded TOC date loads later pages and then updates the hash to the target.
+
+## Computer Use
+
+Computer Use inspected the Zen browser on `http://127.0.0.1:1117/gcores-talks/`. The real browser window showed the production archive with the expected left TOC rail and right feed. Interaction assertions were handled through Playwright for repeatability.
+
+## Visual Evidence
+
+Temporary screenshots were generated under `/tmp/daily-toc-anchor-plus-screens` and visually inspected:
+
+- `iphone17.png`: mobile TOC is in normal flow and `+` is visible.
+- `13-inch.png`: left rail and right feed match the approved Version D behavior.
+- `27-inch.png`: archive remains bounded on wide desktop and does not stretch into empty space.
+
+Screenshots are not committed.
+
+## Residual Risk
+
+- `scripts/daily-sources/*` is not present in this worktree, so the split script could not be fully re-run from raw daily sources. The durable generator was updated, and current `data/daily-toc.json` was updated mechanically from existing `path` values.
+- The full Gcores TOC remains long on mobile. This is consistent with the static-first archive design and can be revisited as a separate filter or collapse enhancement.

--- a/.legion/tasks/daily-toc-anchor-plus/plan.md
+++ b/.legion/tasks/daily-toc-anchor-plus/plan.md
@@ -1,0 +1,68 @@
+# daily-toc-anchor-plus
+
+## Goal
+
+Implement the approved Version D daily archive TOC interaction in production: clicking a TOC date stays on the aggregate archive and scrolls to the matching entry; the small `+` affordance opens the standalone daily page.
+
+## Problem
+
+The current daily archive TOC uses date links as direct links to standalone daily documents. That makes the TOC behave like a jump menu rather than a document outline. The requested Version D interaction splits the two intents:
+
+- primary date link: locate the entry in the current aggregate archive
+- auxiliary `+` link: open the standalone daily document
+
+The production archive is paginated and progressively enhanced with infinite loading, so a robust implementation must also handle TOC targets that are not yet present in the loaded page.
+
+## Acceptance
+
+- `/gcores-talks/`, `/diary/2020/`, and `/diary/2026/` use Version D semantics.
+- Primary TOC date links point to in-page daily entry anchors.
+- A small `+` link appears on hover/focus beside each TOC row on desktop and opens the standalone daily page.
+- On touch/mobile widths, the `+` link remains visible so standalone pages are not hover-only.
+- If the target entry is already loaded, clicking the date scrolls to it.
+- If the target entry is on a later paginated archive page, JavaScript progressively loads subsequent pages until the target appears, then scrolls to it.
+- Without JavaScript, the primary date link still has an anchor href and existing pagination remains available.
+- Existing infinite loading behavior and `继续加载` remain intact.
+- The implementation preserves the terminal-paper style: text links, thin rules, no cards, no filled buttons.
+- Build and browser verification pass on iPhone-sized, 13-inch, and 27-inch viewports.
+
+## Scope
+
+- `themes/cone-scroll/templates/daily-archive.html`
+- `themes/cone-scroll/static/css/style.css`
+- `themes/cone-scroll/static/js/script.js`
+- `scripts/split-daily-logs.mjs` and generated daily TOC data only if anchor metadata needs to be made durable.
+- `.legion/tasks/daily-toc-anchor-plus/**` and relevant wiki writeback.
+
+## Non-goals
+
+- Do not redesign the daily archive beyond Version D.
+- Do not change the date grouping model.
+- Do not change standalone daily page URLs.
+- Do not replace pagination with a client-only feed.
+- Do not alter normal article TOC behavior.
+
+## Assumptions
+
+- Version D is chosen over the right-gutter and day-group variants.
+- The per-entry article `id` remains the stable anchor target for aggregate archive scrolling.
+- The standalone page URL remains available from the existing TOC item `path`.
+- Progressive loading can reuse the existing infinite-loading pagination mechanism instead of inventing a separate fetch path.
+
+## Risks
+
+- TOC links for unloaded entries can fail if JavaScript only changes hrefs without loading later pages.
+- Hover-only `+` can make standalone pages hard to access on touch devices if mobile visibility is not handled.
+- Duplicated same-day entries need per-entry `+` links, because Version D attaches `+` to each visible row rather than grouping by day.
+
+## Design Summary
+
+Implement a quiet inline `+` affordance next to each date/sequence TOC link. The date text remains the document-outline action and scrolls within the aggregate page. The `+` link is a secondary action to the standalone daily document. For targets not yet loaded, an intercepting script should progressively load archive pages using the existing paginator and then scroll to the target once appended.
+
+## Phases
+
+1. Inspect current daily archive template, TOC data, and infinite-loading script.
+2. Implement Version D markup and styling.
+3. Extend the infinite-loading script for TOC anchor resolution.
+4. Build and verify the three daily archive pages across iPhone, 13-inch, and 27-inch viewports.
+5. Review, report, wiki writeback, commit, push PR, follow checks/merge, cleanup.

--- a/.legion/tasks/daily-toc-anchor-plus/tasks.md
+++ b/.legion/tasks/daily-toc-anchor-plus/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+- [x] Initialize LegionMind task contract.
+- [x] Inspect production template, TOC data, and infinite-loading script.
+- [x] Implement Version D markup/CSS/JS.
+- [x] Run build and browser verification.
+- [x] Review implementation against scope and design.
+- [x] Write report, PR body, and wiki summary.
+- [ ] Commit, rebase, push PR, enable squash auto-merge, follow checks, cleanup, refresh main workspace.

--- a/.legion/wiki/index.md
+++ b/.legion/wiki/index.md
@@ -7,9 +7,10 @@
 - `tasks/const-access-sops-apply.md`: SOPS-backed Cloudflare Access apply and encrypted Terraform state handling.
 - `tasks/daily-log-toc-implementation.md`: Daily archive TOC implementation and duplicate-date sequence rule.
 - `tasks/daily-toc-desktop-layout-fix.md`: Daily archive TOC breakpoint correction after production/demo mismatch.
+- `tasks/daily-toc-anchor-plus.md`: Version D TOC behavior, date links locate aggregate entries and `+` opens standalone pages.
 - `patterns.md`: Reusable theme and archive implementation conventions.
 - `maintenance.md`: Follow-up implementation backlog.
 
 ## Current Truth
 
-The blog is a Zola static archive with a deliberate terminal-paper visual language. Long daily-log pages should be split into atomic Markdown pages through static sections and pagination. Daily archive navigation should look like a document TOC, with infinite loading used only as progressive enhancement. The `/const` path is protected by Cloudflare Access through Terraform, with Cloudflare/Terraform private inputs and local state managed through SOPS encrypted files.
+The blog is a Zola static archive with a deliberate terminal-paper visual language. Long daily-log pages should be split into atomic Markdown pages through static sections and pagination. Daily archive navigation should look like a document TOC: primary date links locate aggregate entries, while inline `+` links open standalone daily pages. Infinite loading is only progressive enhancement. The `/const` path is protected by Cloudflare Access through Terraform, with Cloudflare/Terraform private inputs and local state managed through SOPS encrypted files.

--- a/.legion/wiki/log.md
+++ b/.legion/wiki/log.md
@@ -15,3 +15,8 @@
 - Added task summary for `const-access-sops-apply`.
 - Promoted the SOPS-backed Terraform apply pattern: encrypted env inputs, temporary plaintext state only during operations, encrypted JSON state as durable copy, plan scope gate, and no raw secret-bearing evidence in docs.
 - Updated current truth to note `/const` is protected by Cloudflare Access with SOPS-managed private inputs/state.
+
+## 2026-06-12
+- Added task summary for `daily-toc-anchor-plus`.
+- Promoted the Version D daily archive TOC rule: primary date links locate entries in the aggregate archive, while inline `+` links open standalone daily pages.
+- Promoted the lazy anchor-resolution rule: unloaded TOC targets should use existing pagination/infinite loading, not a separate client-only data path.

--- a/.legion/wiki/patterns.md
+++ b/.legion/wiki/patterns.md
@@ -27,12 +27,16 @@ Infinite loading is a progressive enhancement over real pagination:
 For daily archive navigation, prefer document-outline navigation over form controls:
 
 - use the existing `.page-outline` visual language
-- render dates as plain links, not select options
+- render dates as plain in-page anchor links, not select options
+- use a small inline `+` for the standalone daily page action
+- keep `+` visible on mobile and touch, because hover is unavailable
 - group duplicate-date sources under the date with stable sequence labels
+- give each duplicate sequence row its own standalone `+` link
 - keep mobile access in normal document flow with native `<details>`
 - keep desktop access as a sticky left rail with a thin divider
 - verify desktop/laptop archive pages by asserting left/right placement, not only by checking that screenshots have no overlap
 - keep the daily archive rail breakpoint aligned with the approved dummy behavior unless a new design explicitly changes it
+- when a TOC target is not loaded yet, resolve it through the existing paginator/infinite loader instead of introducing a client-only feed path
 
 ## Terminal-Paper UI Preservation
 

--- a/.legion/wiki/tasks/daily-toc-anchor-plus.md
+++ b/.legion/wiki/tasks/daily-toc-anchor-plus.md
@@ -1,0 +1,35 @@
+# daily-toc-anchor-plus
+
+## Status
+
+Implemented and verified; pending PR lifecycle at time of writeback.
+
+## Problem
+
+The daily archive TOC linked directly to standalone daily pages. The approved Version D interaction separates the two actions:
+
+- click the date/title to locate the entry in the aggregate archive
+- hover/focus the row and use `+` to open the standalone daily page
+
+This needed to work with existing pagination and infinite loading because many TOC targets are not present in the first rendered page.
+
+## Decision
+
+Daily TOC data now includes a stable `anchor` derived from the standalone URL slug. Templates render date and sequence labels as `#anchor` links and render `+` as the standalone URL.
+
+The existing infinite loader is reused by TOC navigation. If a clicked anchor is missing, the script loads subsequent pages until the target article appears, then scrolls and focuses it.
+
+## Verification
+
+- `git diff --check` passed.
+- `node --check themes/cone-scroll/static/js/script.js` passed.
+- `zola build` passed.
+- `/gcores-talks/`, `/diary/2020/`, and `/diary/2026/` passed Playwright checks at `393x852`, `1440x900`, and `2560x1440`.
+- Computer Use inspected the local Zen browser on `/gcores-talks/`.
+
+## Durable Notes
+
+- Mobile and touch layouts must show the standalone `+` link without hover.
+- Desktop should keep the `+` visually quiet until hover or focus.
+- Same-day duplicate entries need per-entry `+` links, not one date-level link.
+- TOC anchor resolution should reuse real pagination, not introduce a client-only data path.

--- a/data/daily-toc.json
+++ b/data/daily-toc.json
@@ -12,7 +12,8 @@
               "path": "/diary/2020/2020-07-22/",
               "title": "2020-07-22",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-07-22"
             }
           ]
         },
@@ -25,7 +26,8 @@
               "path": "/diary/2020/2020-07-13/",
               "title": "2020-07-13",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-07-13"
             }
           ]
         },
@@ -38,7 +40,8 @@
               "path": "/diary/2020/2020-07-10/",
               "title": "2020-07-10",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-07-10"
             }
           ]
         },
@@ -51,7 +54,8 @@
               "path": "/diary/2020/2020-07-09/",
               "title": "2020-07-09",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-07-09"
             }
           ]
         },
@@ -64,7 +68,8 @@
               "path": "/diary/2020/2020-07-07/",
               "title": "2020-07-07",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-07-07"
             }
           ]
         },
@@ -77,7 +82,8 @@
               "path": "/diary/2020/2020-07-06/",
               "title": "2020-07-06",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-07-06"
             }
           ]
         },
@@ -90,7 +96,8 @@
               "path": "/diary/2020/2020-07-02/",
               "title": "2020-07-02",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-07-02"
             }
           ]
         },
@@ -103,7 +110,8 @@
               "path": "/diary/2020/2020-07-01/",
               "title": "2020-07-01",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-07-01"
             }
           ]
         }
@@ -121,7 +129,8 @@
               "path": "/diary/2020/2020-06-30/",
               "title": "2020-06-30",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-06-30"
             }
           ]
         },
@@ -134,7 +143,8 @@
               "path": "/diary/2020/2020-06-29/",
               "title": "2020-06-29",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-06-29"
             }
           ]
         },
@@ -147,7 +157,8 @@
               "path": "/diary/2020/2020-06-28/",
               "title": "2020-06-28",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-06-28"
             }
           ]
         },
@@ -160,7 +171,8 @@
               "path": "/diary/2020/2020-06-24/",
               "title": "2020-06-24",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-06-24"
             }
           ]
         },
@@ -173,7 +185,8 @@
               "path": "/diary/2020/2020-06-23/",
               "title": "2020-06-23",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-06-23"
             }
           ]
         },
@@ -186,7 +199,8 @@
               "path": "/diary/2020/2020-06-22/",
               "title": "2020-06-22",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-06-22"
             }
           ]
         },
@@ -199,7 +213,8 @@
               "path": "/diary/2020/2020-06-19/",
               "title": "2020-06-19",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-06-19"
             }
           ]
         },
@@ -212,7 +227,8 @@
               "path": "/diary/2020/2020-06-18/",
               "title": "2020-06-18",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-06-18"
             }
           ]
         },
@@ -225,7 +241,8 @@
               "path": "/diary/2020/2020-06-17/",
               "title": "2020-06-17",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-06-17"
             }
           ]
         },
@@ -238,7 +255,8 @@
               "path": "/diary/2020/2020-06-16/",
               "title": "2020-06-16",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-06-16"
             }
           ]
         },
@@ -251,7 +269,8 @@
               "path": "/diary/2020/2020-06-15/",
               "title": "2020-06-15",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-06-15"
             }
           ]
         },
@@ -264,7 +283,8 @@
               "path": "/diary/2020/2020-06-13/",
               "title": "2020-06-13",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-06-13"
             }
           ]
         },
@@ -277,7 +297,8 @@
               "path": "/diary/2020/2020-06-12/",
               "title": "2020-06-12",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-06-12"
             }
           ]
         },
@@ -290,7 +311,8 @@
               "path": "/diary/2020/2020-06-11/",
               "title": "2020-06-11",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-06-11"
             }
           ]
         },
@@ -303,7 +325,8 @@
               "path": "/diary/2020/2020-06-10/",
               "title": "2020-06-10",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-06-10"
             }
           ]
         },
@@ -316,7 +339,8 @@
               "path": "/diary/2020/2020-06-09/",
               "title": "2020-06-09",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-06-09"
             }
           ]
         },
@@ -329,7 +353,8 @@
               "path": "/diary/2020/2020-06-08/",
               "title": "2020-06-08",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-06-08"
             }
           ]
         },
@@ -342,7 +367,8 @@
               "path": "/diary/2020/2020-06-05/",
               "title": "2020-06-05",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-06-05"
             }
           ]
         },
@@ -355,7 +381,8 @@
               "path": "/diary/2020/2020-06-04/",
               "title": "2020-06-04",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-06-04"
             }
           ]
         },
@@ -368,7 +395,8 @@
               "path": "/diary/2020/2020-06-03/",
               "title": "2020-06-03",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-06-03"
             }
           ]
         },
@@ -381,7 +409,8 @@
               "path": "/diary/2020/2020-06-02/",
               "title": "2020-06-02",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-06-02"
             }
           ]
         },
@@ -394,7 +423,8 @@
               "path": "/diary/2020/2020-06-01/",
               "title": "2020-06-01",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-06-01"
             }
           ]
         }
@@ -412,7 +442,8 @@
               "path": "/diary/2020/2020-05-29/",
               "title": "2020-05-29",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-05-29"
             }
           ]
         },
@@ -425,7 +456,8 @@
               "path": "/diary/2020/2020-05-28/",
               "title": "2020-05-28",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-05-28"
             }
           ]
         },
@@ -438,7 +470,8 @@
               "path": "/diary/2020/2020-05-27/",
               "title": "2020-05-27",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-05-27"
             }
           ]
         },
@@ -451,7 +484,8 @@
               "path": "/diary/2020/2020-05-26/",
               "title": "2020-05-26",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-05-26"
             }
           ]
         },
@@ -464,7 +498,8 @@
               "path": "/diary/2020/2020-05-25/",
               "title": "2020-05-25",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-05-25"
             }
           ]
         },
@@ -477,7 +512,8 @@
               "path": "/diary/2020/2020-05-22/",
               "title": "2020-05-22",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-05-22"
             }
           ]
         },
@@ -490,7 +526,8 @@
               "path": "/diary/2020/2020-05-21/",
               "title": "2020-05-21",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-05-21"
             }
           ]
         },
@@ -503,7 +540,8 @@
               "path": "/diary/2020/2020-05-20/",
               "title": "2020-05-20",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-05-20"
             }
           ]
         },
@@ -516,7 +554,8 @@
               "path": "/diary/2020/2020-05-19/",
               "title": "2020-05-19",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-05-19"
             }
           ]
         },
@@ -529,7 +568,8 @@
               "path": "/diary/2020/2020-05-18/",
               "title": "2020-05-18",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-05-18"
             }
           ]
         },
@@ -542,7 +582,8 @@
               "path": "/diary/2020/2020-05-15/",
               "title": "2020-05-15",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-05-15"
             }
           ]
         },
@@ -555,7 +596,8 @@
               "path": "/diary/2020/2020-05-14/",
               "title": "2020-05-14",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-05-14"
             }
           ]
         },
@@ -568,7 +610,8 @@
               "path": "/diary/2020/2020-05-13/",
               "title": "2020-05-13",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-05-13"
             }
           ]
         },
@@ -581,7 +624,8 @@
               "path": "/diary/2020/2020-05-12/",
               "title": "2020-05-12",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-05-12"
             }
           ]
         },
@@ -594,7 +638,8 @@
               "path": "/diary/2020/2020-05-11/",
               "title": "2020-05-11",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-05-11"
             }
           ]
         },
@@ -607,7 +652,8 @@
               "path": "/diary/2020/2020-05-09/",
               "title": "2020-05-09",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-05-09"
             }
           ]
         },
@@ -620,7 +666,8 @@
               "path": "/diary/2020/2020-05-08/",
               "title": "2020-05-08",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-05-08"
             }
           ]
         },
@@ -633,7 +680,8 @@
               "path": "/diary/2020/2020-05-06/",
               "title": "2020-05-06",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-05-06"
             }
           ]
         }
@@ -651,7 +699,8 @@
               "path": "/diary/2020/2020-04-29/",
               "title": "2020-04-29",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-04-29"
             }
           ]
         },
@@ -664,7 +713,8 @@
               "path": "/diary/2020/2020-04-28/",
               "title": "2020-04-28",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-04-28"
             }
           ]
         },
@@ -677,7 +727,8 @@
               "path": "/diary/2020/2020-04-27/",
               "title": "2020-04-27",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-04-27"
             }
           ]
         },
@@ -690,7 +741,8 @@
               "path": "/diary/2020/2020-04-23/",
               "title": "2020-04-23",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-04-23"
             }
           ]
         },
@@ -703,7 +755,8 @@
               "path": "/diary/2020/2020-04-22/",
               "title": "2020-04-22",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-04-22"
             }
           ]
         },
@@ -716,7 +769,8 @@
               "path": "/diary/2020/2020-04-21/",
               "title": "2020-04-21",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-04-21"
             }
           ]
         },
@@ -729,7 +783,8 @@
               "path": "/diary/2020/2020-04-20/",
               "title": "2020-04-20",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-04-20"
             }
           ]
         },
@@ -742,7 +797,8 @@
               "path": "/diary/2020/2020-04-18/",
               "title": "2020-04-18",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-04-18"
             }
           ]
         },
@@ -755,7 +811,8 @@
               "path": "/diary/2020/2020-04-17/",
               "title": "2020-04-17",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-04-17"
             }
           ]
         },
@@ -768,7 +825,8 @@
               "path": "/diary/2020/2020-04-16/",
               "title": "2020-04-16",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-04-16"
             }
           ]
         },
@@ -781,7 +839,8 @@
               "path": "/diary/2020/2020-04-15/",
               "title": "2020-04-15",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-04-15"
             }
           ]
         },
@@ -794,7 +853,8 @@
               "path": "/diary/2020/2020-04-14/",
               "title": "2020-04-14",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-04-14"
             }
           ]
         },
@@ -807,7 +867,8 @@
               "path": "/diary/2020/2020-04-13/",
               "title": "2020-04-13",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2020-04-13"
             }
           ]
         }
@@ -827,7 +888,8 @@
               "path": "/diary/2026/2026-04-23/",
               "title": "2026-04-23",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2026-04-23"
             }
           ]
         }
@@ -845,7 +907,8 @@
               "path": "/diary/2026/2026-03-24/",
               "title": "2026-03-24",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2026-03-24"
             }
           ]
         },
@@ -858,7 +921,8 @@
               "path": "/diary/2026/2026-03-17/",
               "title": "2026-03-17",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2026-03-17"
             }
           ]
         }
@@ -876,7 +940,8 @@
               "path": "/diary/2026/2026-02-05/",
               "title": "2026-02-05",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2026-02-05"
             }
           ]
         },
@@ -889,7 +954,8 @@
               "path": "/diary/2026/2026-02-02/",
               "title": "2026-02-02",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2026-02-02"
             }
           ]
         },
@@ -902,7 +968,8 @@
               "path": "/diary/2026/2026-02-01/",
               "title": "2026-02-01",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2026-02-01"
             }
           ]
         }
@@ -920,7 +987,8 @@
               "path": "/diary/2026/2026-01-31/",
               "title": "2026-01-31",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2026-01-31"
             }
           ]
         },
@@ -933,7 +1001,8 @@
               "path": "/diary/2026/2026-01-27/",
               "title": "2026-01-27",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2026-01-27"
             }
           ]
         },
@@ -946,7 +1015,8 @@
               "path": "/diary/2026/2026-01-26/",
               "title": "2026-01-26",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2026-01-26"
             }
           ]
         },
@@ -959,7 +1029,8 @@
               "path": "/diary/2026/2026-01-25/",
               "title": "2026-01-25",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2026-01-25"
             }
           ]
         },
@@ -972,7 +1043,8 @@
               "path": "/diary/2026/2026-01-24/",
               "title": "2026-01-24",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2026-01-24"
             }
           ]
         },
@@ -985,7 +1057,8 @@
               "path": "/diary/2026/2026-01-23/",
               "title": "2026-01-23",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2026-01-23"
             }
           ]
         },
@@ -998,7 +1071,8 @@
               "path": "/diary/2026/2026-01-22/",
               "title": "2026-01-22",
               "topic": "",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2026-01-22"
             }
           ]
         }
@@ -1018,7 +1092,8 @@
               "path": "/gcores-talks/2026-01-01/",
               "title": "2026-01-01",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2026-01-01"
             }
           ]
         }
@@ -1036,7 +1111,8 @@
               "path": "/gcores-talks/2025-12-22/",
               "title": "2025-12-22",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2025-12-22"
             }
           ]
         },
@@ -1049,7 +1125,8 @@
               "path": "/gcores-talks/2025-12-08/",
               "title": "2025-12-08",
               "topic": "🍺都在酒里",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2025-12-08"
             }
           ]
         },
@@ -1062,7 +1139,8 @@
               "path": "/gcores-talks/2025-11-06/",
               "title": "2025-11-06",
               "topic": "💓情感妙妙屋",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2025-11-06"
             }
           ]
         },
@@ -1075,7 +1153,8 @@
               "path": "/gcores-talks/2025-10-06/",
               "title": "2025-10-06",
               "topic": "🍂秋日的第一抹色彩",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2025-10-06"
             }
           ]
         },
@@ -1088,7 +1167,8 @@
               "path": "/gcores-talks/2025-09-21/",
               "title": "2025-09-21",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2025-09-21"
             }
           ]
         },
@@ -1101,7 +1181,8 @@
               "path": "/gcores-talks/2025-09-15/",
               "title": "2025-09-15",
               "topic": "🛡️DOTA2赛事讨论",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2025-09-15"
             }
           ]
         },
@@ -1114,7 +1195,8 @@
               "path": "/gcores-talks/2025-09-14/",
               "title": "2025-09-14",
               "topic": "🛡️DOTA2赛事讨论",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2025-09-14"
             }
           ]
         },
@@ -1127,7 +1209,8 @@
               "path": "/gcores-talks/2025-09-13/",
               "title": "2025-09-13",
               "topic": "🛡️DOTA2赛事讨论",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2025-09-13"
             }
           ]
         },
@@ -1140,7 +1223,8 @@
               "path": "/gcores-talks/2025-09-12/",
               "title": "2025-09-12",
               "topic": "🛡️DOTA2赛事讨论",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2025-09-12"
             }
           ]
         },
@@ -1153,13 +1237,15 @@
               "path": "/gcores-talks/2025-07-23-01/",
               "title": "2025-07-23 #1",
               "topic": "🧳出去走走",
-              "sequence_label": "01"
+              "sequence_label": "01",
+              "anchor": "2025-07-23-01"
             },
             {
               "path": "/gcores-talks/2025-07-23-02/",
               "title": "2025-07-23 #2",
               "topic": "🌙emo树洞",
-              "sequence_label": "02"
+              "sequence_label": "02",
+              "anchor": "2025-07-23-02"
             }
           ]
         },
@@ -1172,7 +1258,8 @@
               "path": "/gcores-talks/2025-07-20/",
               "title": "2025-07-20",
               "topic": "💓情感妙妙屋",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2025-07-20"
             }
           ]
         },
@@ -1185,7 +1272,8 @@
               "path": "/gcores-talks/2025-07-09/",
               "title": "2025-07-09",
               "topic": "🤔发癫发狂！癫火之王！",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2025-07-09"
             }
           ]
         },
@@ -1198,7 +1286,8 @@
               "path": "/gcores-talks/2025-06-27/",
               "title": "2025-06-27",
               "topic": "🐒黑神话 悟空",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2025-06-27"
             }
           ]
         },
@@ -1211,7 +1300,8 @@
               "path": "/gcores-talks/2025-06-21/",
               "title": "2025-06-21",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2025-06-21"
             }
           ]
         },
@@ -1224,7 +1314,8 @@
               "path": "/gcores-talks/2025-06-01/",
               "title": "2025-06-01",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2025-06-01"
             }
           ]
         },
@@ -1237,7 +1328,8 @@
               "path": "/gcores-talks/2025-05-11/",
               "title": "2025-05-11",
               "topic": "🎁BOOOM游玩感想反馈站",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2025-05-11"
             }
           ]
         },
@@ -1250,7 +1342,8 @@
               "path": "/gcores-talks/2025-03-16/",
               "title": "2025-03-16",
               "topic": "🧩碎片故事",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2025-03-16"
             }
           ]
         },
@@ -1263,7 +1356,8 @@
               "path": "/gcores-talks/2025-03-04/",
               "title": "2025-03-04",
               "topic": "🪄《怪物猎人 荒野》捏脸征集",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2025-03-04"
             }
           ]
         }
@@ -1281,7 +1375,8 @@
               "path": "/gcores-talks/2024-12-22/",
               "title": "2024-12-22",
               "topic": "🧩碎片故事",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-12-22"
             }
           ]
         },
@@ -1294,13 +1389,15 @@
               "path": "/gcores-talks/2024-12-18-01/",
               "title": "2024-12-18 #1",
               "topic": "🧩碎片故事",
-              "sequence_label": "01"
+              "sequence_label": "01",
+              "anchor": "2024-12-18-01"
             },
             {
               "path": "/gcores-talks/2024-12-18-02/",
               "title": "2024-12-18 #2",
               "topic": "✝️赛博告解室",
-              "sequence_label": "02"
+              "sequence_label": "02",
+              "anchor": "2024-12-18-02"
             }
           ]
         },
@@ -1313,13 +1410,15 @@
               "path": "/gcores-talks/2024-12-02-01/",
               "title": "2024-12-02 #1",
               "topic": "✝️赛博告解室",
-              "sequence_label": "01"
+              "sequence_label": "01",
+              "anchor": "2024-12-02-01"
             },
             {
               "path": "/gcores-talks/2024-12-02-02/",
               "title": "2024-12-02 #2",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": "02"
+              "sequence_label": "02",
+              "anchor": "2024-12-02-02"
             }
           ]
         },
@@ -1332,7 +1431,8 @@
               "path": "/gcores-talks/2024-12-01/",
               "title": "2024-12-01",
               "topic": "✝️赛博告解室",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-12-01"
             }
           ]
         },
@@ -1345,13 +1445,15 @@
               "path": "/gcores-talks/2024-11-28-01/",
               "title": "2024-11-28 #1",
               "topic": "💎机核宝藏内容推荐",
-              "sequence_label": "01"
+              "sequence_label": "01",
+              "anchor": "2024-11-28-01"
             },
             {
               "path": "/gcores-talks/2024-11-28-02/",
               "title": "2024-11-28 #2",
               "topic": "🎲跑团逸闻录",
-              "sequence_label": "02"
+              "sequence_label": "02",
+              "anchor": "2024-11-28-02"
             }
           ]
         },
@@ -1364,13 +1466,15 @@
               "path": "/gcores-talks/2024-11-19-01/",
               "title": "2024-11-19 #1",
               "topic": "🧩碎片故事",
-              "sequence_label": "01"
+              "sequence_label": "01",
+              "anchor": "2024-11-19-01"
             },
             {
               "path": "/gcores-talks/2024-11-19-02/",
               "title": "2024-11-19 #2",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": "02"
+              "sequence_label": "02",
+              "anchor": "2024-11-19-02"
             }
           ]
         },
@@ -1383,7 +1487,8 @@
               "path": "/gcores-talks/2024-09-29/",
               "title": "2024-09-29",
               "topic": "🧳出去走走",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-09-29"
             }
           ]
         },
@@ -1396,7 +1501,8 @@
               "path": "/gcores-talks/2024-09-27/",
               "title": "2024-09-27",
               "topic": "🧳出去走走",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-09-27"
             }
           ]
         },
@@ -1409,7 +1515,8 @@
               "path": "/gcores-talks/2024-09-17/",
               "title": "2024-09-17",
               "topic": "🧳出去走走",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-09-17"
             }
           ]
         },
@@ -1422,7 +1529,8 @@
               "path": "/gcores-talks/2024-09-06/",
               "title": "2024-09-06",
               "topic": "🧳出去走走",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-09-06"
             }
           ]
         },
@@ -1435,7 +1543,8 @@
               "path": "/gcores-talks/2024-08-28/",
               "title": "2024-08-28",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-08-28"
             }
           ]
         },
@@ -1448,7 +1557,8 @@
               "path": "/gcores-talks/2024-08-20/",
               "title": "2024-08-20",
               "topic": "⚙吉考斯工业",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-08-20"
             }
           ]
         },
@@ -1461,7 +1571,8 @@
               "path": "/gcores-talks/2024-08-18/",
               "title": "2024-08-18",
               "topic": "✝️赛博告解室",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-08-18"
             }
           ]
         },
@@ -1474,7 +1585,8 @@
               "path": "/gcores-talks/2024-08-05/",
               "title": "2024-08-05",
               "topic": "🤔发癫发狂！癫火之王！",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-08-05"
             }
           ]
         },
@@ -1487,7 +1599,8 @@
               "path": "/gcores-talks/2024-07-28/",
               "title": "2024-07-28",
               "topic": "🚶🏻旷野漫步者",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-07-28"
             }
           ]
         },
@@ -1500,7 +1613,8 @@
               "path": "/gcores-talks/2024-07-22/",
               "title": "2024-07-22",
               "topic": "🎵这周听了啥",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-07-22"
             }
           ]
         },
@@ -1513,7 +1627,8 @@
               "path": "/gcores-talks/2024-07-20/",
               "title": "2024-07-20",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-07-20"
             }
           ]
         },
@@ -1526,7 +1641,8 @@
               "path": "/gcores-talks/2024-07-13/",
               "title": "2024-07-13",
               "topic": "🎦观影杂感",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-07-13"
             }
           ]
         },
@@ -1539,7 +1655,8 @@
               "path": "/gcores-talks/2024-07-10/",
               "title": "2024-07-10",
               "topic": "🎮关于这个游戏的感受",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-07-10"
             }
           ]
         },
@@ -1552,7 +1669,8 @@
               "path": "/gcores-talks/2024-07-07/",
               "title": "2024-07-07",
               "topic": "♟️来点儿桌游",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-07-07"
             }
           ]
         },
@@ -1565,7 +1683,8 @@
               "path": "/gcores-talks/2024-07-06/",
               "title": "2024-07-06",
               "topic": "🎮关于这个游戏的感受",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-07-06"
             }
           ]
         },
@@ -1578,7 +1697,8 @@
               "path": "/gcores-talks/2024-06-29/",
               "title": "2024-06-29",
               "topic": "🥨褪色者游记",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-06-29"
             }
           ]
         },
@@ -1591,7 +1711,8 @@
               "path": "/gcores-talks/2024-06-08/",
               "title": "2024-06-08",
               "topic": "🔖这段太精彩了",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-06-08"
             }
           ]
         },
@@ -1604,7 +1725,8 @@
               "path": "/gcores-talks/2024-06-06/",
               "title": "2024-06-06",
               "topic": "✨游戏高光时刻",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-06-06"
             }
           ]
         },
@@ -1617,7 +1739,8 @@
               "path": "/gcores-talks/2024-05-29/",
               "title": "2024-05-29",
               "topic": "🧑🏻‍🦼虚拟主播",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-05-29"
             }
           ]
         },
@@ -1630,7 +1753,8 @@
               "path": "/gcores-talks/2024-05-28/",
               "title": "2024-05-28",
               "topic": "🧑🏻‍🦼虚拟主播",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-05-28"
             }
           ]
         },
@@ -1643,7 +1767,8 @@
               "path": "/gcores-talks/2024-05-21/",
               "title": "2024-05-21",
               "topic": "💥核聚变",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-05-21"
             }
           ]
         },
@@ -1656,7 +1781,8 @@
               "path": "/gcores-talks/2024-05-07/",
               "title": "2024-05-07",
               "topic": "🧑🏻‍💻开发日志",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-05-07"
             }
           ]
         },
@@ -1669,7 +1795,8 @@
               "path": "/gcores-talks/2024-03-22/",
               "title": "2024-03-22",
               "topic": "🎦观影杂感",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-03-22"
             }
           ]
         },
@@ -1682,7 +1809,8 @@
               "path": "/gcores-talks/2024-02-20/",
               "title": "2024-02-20",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-02-20"
             }
           ]
         },
@@ -1695,7 +1823,8 @@
               "path": "/gcores-talks/2024-02-12/",
               "title": "2024-02-12",
               "topic": "🧨过年啦",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-02-12"
             }
           ]
         },
@@ -1708,13 +1837,15 @@
               "path": "/gcores-talks/2024-02-10-01/",
               "title": "2024-02-10 #1",
               "topic": "📓我的年度总结",
-              "sequence_label": "01"
+              "sequence_label": "01",
+              "anchor": "2024-02-10-01"
             },
             {
               "path": "/gcores-talks/2024-02-10-02/",
               "title": "2024-02-10 #2",
               "topic": "📓我的年度总结",
-              "sequence_label": "02"
+              "sequence_label": "02",
+              "anchor": "2024-02-10-02"
             }
           ]
         },
@@ -1727,7 +1858,8 @@
               "path": "/gcores-talks/2024-02-03/",
               "title": "2024-02-03",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-02-03"
             }
           ]
         },
@@ -1740,7 +1872,8 @@
               "path": "/gcores-talks/2024-02-02/",
               "title": "2024-02-02",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-02-02"
             }
           ]
         },
@@ -1753,7 +1886,8 @@
               "path": "/gcores-talks/2024-02-01/",
               "title": "2024-02-01",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-02-01"
             }
           ]
         },
@@ -1766,7 +1900,8 @@
               "path": "/gcores-talks/2024-01-31/",
               "title": "2024-01-31",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-01-31"
             }
           ]
         },
@@ -1779,7 +1914,8 @@
               "path": "/gcores-talks/2024-01-23/",
               "title": "2024-01-23",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-01-23"
             }
           ]
         },
@@ -1792,7 +1928,8 @@
               "path": "/gcores-talks/2024-01-19/",
               "title": "2024-01-19",
               "topic": "🏆2023我最喜欢的5款游戏",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-01-19"
             }
           ]
         },
@@ -1805,7 +1942,8 @@
               "path": "/gcores-talks/2024-01-13/",
               "title": "2024-01-13",
               "topic": "🎮关于这个游戏的感受",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-01-13"
             }
           ]
         },
@@ -1818,7 +1956,8 @@
               "path": "/gcores-talks/2024-01-06/",
               "title": "2024-01-06",
               "topic": "🧚俗世奇人",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-01-06"
             }
           ]
         },
@@ -1831,7 +1970,8 @@
               "path": "/gcores-talks/2024-01-02/",
               "title": "2024-01-02",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-01-02"
             }
           ]
         },
@@ -1844,7 +1984,8 @@
               "path": "/gcores-talks/2024-01-01/",
               "title": "2024-01-01",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2024-01-01"
             }
           ]
         }
@@ -1862,7 +2003,8 @@
               "path": "/gcores-talks/2023-12-29/",
               "title": "2023-12-29",
               "topic": "💪FLAG打卡记录站",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-12-29"
             }
           ]
         },
@@ -1875,13 +2017,15 @@
               "path": "/gcores-talks/2023-11-21-01/",
               "title": "2023-11-21 #1",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": "01"
+              "sequence_label": "01",
+              "anchor": "2023-11-21-01"
             },
             {
               "path": "/gcores-talks/2023-11-21-02/",
               "title": "2023-11-21 #2",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": "02"
+              "sequence_label": "02",
+              "anchor": "2023-11-21-02"
             }
           ]
         },
@@ -1894,7 +2038,8 @@
               "path": "/gcores-talks/2023-11-18/",
               "title": "2023-11-18",
               "topic": "🥘机组美食城",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-11-18"
             }
           ]
         },
@@ -1907,7 +2052,8 @@
               "path": "/gcores-talks/2023-10-31/",
               "title": "2023-10-31",
               "topic": "🧳出去走走",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-10-31"
             }
           ]
         },
@@ -1920,7 +2066,8 @@
               "path": "/gcores-talks/2023-10-17/",
               "title": "2023-10-17",
               "topic": "🌕午夜诗人",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-10-17"
             }
           ]
         },
@@ -1933,7 +2080,8 @@
               "path": "/gcores-talks/2023-10-10/",
               "title": "2023-10-10",
               "topic": "🎵这周听了啥",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-10-10"
             }
           ]
         },
@@ -1946,7 +2094,8 @@
               "path": "/gcores-talks/2023-10-04/",
               "title": "2023-10-04",
               "topic": "✨日子人的生活小妙招",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-10-04"
             }
           ]
         },
@@ -1959,7 +2108,8 @@
               "path": "/gcores-talks/2023-10-02/",
               "title": "2023-10-02",
               "topic": "🆚印象深刻的电竞赛事",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-10-02"
             }
           ]
         },
@@ -1972,7 +2122,8 @@
               "path": "/gcores-talks/2023-09-28/",
               "title": "2023-09-28",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-09-28"
             }
           ]
         },
@@ -1985,7 +2136,8 @@
               "path": "/gcores-talks/2023-09-16/",
               "title": "2023-09-16",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-09-16"
             }
           ]
         },
@@ -1998,7 +2150,8 @@
               "path": "/gcores-talks/2023-09-13/",
               "title": "2023-09-13",
               "topic": "🍡怪物猎人 崛起",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-09-13"
             }
           ]
         },
@@ -2011,7 +2164,8 @@
               "path": "/gcores-talks/2023-08-22/",
               "title": "2023-08-22",
               "topic": "🚴飙速宅男",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-08-22"
             }
           ]
         },
@@ -2024,7 +2178,8 @@
               "path": "/gcores-talks/2023-08-15/",
               "title": "2023-08-15",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-08-15"
             }
           ]
         },
@@ -2037,7 +2192,8 @@
               "path": "/gcores-talks/2023-08-12/",
               "title": "2023-08-12",
               "topic": "🍺都在酒里",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-08-12"
             }
           ]
         },
@@ -2050,7 +2206,8 @@
               "path": "/gcores-talks/2023-08-04/",
               "title": "2023-08-04",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-08-04"
             }
           ]
         },
@@ -2063,7 +2220,8 @@
               "path": "/gcores-talks/2023-07-21/",
               "title": "2023-07-21",
               "topic": "🍙动画打卡",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-07-21"
             }
           ]
         },
@@ -2076,7 +2234,8 @@
               "path": "/gcores-talks/2023-07-18/",
               "title": "2023-07-18",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-07-18"
             }
           ]
         },
@@ -2089,7 +2248,8 @@
               "path": "/gcores-talks/2023-07-09/",
               "title": "2023-07-09",
               "topic": "🍵饮茶Time",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-07-09"
             }
           ]
         },
@@ -2102,7 +2262,8 @@
               "path": "/gcores-talks/2023-07-07/",
               "title": "2023-07-07",
               "topic": "🐟社畜茶水间",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-07-07"
             }
           ]
         },
@@ -2115,7 +2276,8 @@
               "path": "/gcores-talks/2023-07-02/",
               "title": "2023-07-02",
               "topic": "🎵这周听了啥",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-07-02"
             }
           ]
         },
@@ -2128,7 +2290,8 @@
               "path": "/gcores-talks/2023-07-01/",
               "title": "2023-07-01",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-07-01"
             }
           ]
         },
@@ -2141,7 +2304,8 @@
               "path": "/gcores-talks/2023-06-29/",
               "title": "2023-06-29",
               "topic": "😎显摆显摆",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-06-29"
             }
           ]
         },
@@ -2154,7 +2318,8 @@
               "path": "/gcores-talks/2023-06-27/",
               "title": "2023-06-27",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-06-27"
             }
           ]
         },
@@ -2167,7 +2332,8 @@
               "path": "/gcores-talks/2023-06-26/",
               "title": "2023-06-26",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-06-26"
             }
           ]
         },
@@ -2180,7 +2346,8 @@
               "path": "/gcores-talks/2023-06-20/",
               "title": "2023-06-20",
               "topic": "🎵这周听了啥",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-06-20"
             }
           ]
         },
@@ -2193,7 +2360,8 @@
               "path": "/gcores-talks/2023-06-19/",
               "title": "2023-06-19",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-06-19"
             }
           ]
         },
@@ -2206,13 +2374,15 @@
               "path": "/gcores-talks/2023-06-18-01/",
               "title": "2023-06-18 #1",
               "topic": "🎦观影杂感",
-              "sequence_label": "01"
+              "sequence_label": "01",
+              "anchor": "2023-06-18-01"
             },
             {
               "path": "/gcores-talks/2023-06-18-02/",
               "title": "2023-06-18 #2",
               "topic": "💪FLAG打卡记录站",
-              "sequence_label": "02"
+              "sequence_label": "02",
+              "anchor": "2023-06-18-02"
             }
           ]
         },
@@ -2225,7 +2395,8 @@
               "path": "/gcores-talks/2023-06-15/",
               "title": "2023-06-15",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-06-15"
             }
           ]
         },
@@ -2238,7 +2409,8 @@
               "path": "/gcores-talks/2023-06-13/",
               "title": "2023-06-13",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-06-13"
             }
           ]
         },
@@ -2251,13 +2423,15 @@
               "path": "/gcores-talks/2023-06-12-01/",
               "title": "2023-06-12 #1",
               "topic": "💪FLAG打卡记录站",
-              "sequence_label": "01"
+              "sequence_label": "01",
+              "anchor": "2023-06-12-01"
             },
             {
               "path": "/gcores-talks/2023-06-12-02/",
               "title": "2023-06-12 #2",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": "02"
+              "sequence_label": "02",
+              "anchor": "2023-06-12-02"
             }
           ]
         },
@@ -2270,7 +2444,8 @@
               "path": "/gcores-talks/2023-06-10/",
               "title": "2023-06-10",
               "topic": "🏅️程序猿杰作",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-06-10"
             }
           ]
         },
@@ -2283,13 +2458,15 @@
               "path": "/gcores-talks/2023-06-09-01/",
               "title": "2023-06-09 #1",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": "01"
+              "sequence_label": "01",
+              "anchor": "2023-06-09-01"
             },
             {
               "path": "/gcores-talks/2023-06-09-02/",
               "title": "2023-06-09 #2",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": "02"
+              "sequence_label": "02",
+              "anchor": "2023-06-09-02"
             }
           ]
         },
@@ -2302,13 +2479,15 @@
               "path": "/gcores-talks/2023-06-07-01/",
               "title": "2023-06-07 #1",
               "topic": "🎵这周听了啥",
-              "sequence_label": "01"
+              "sequence_label": "01",
+              "anchor": "2023-06-07-01"
             },
             {
               "path": "/gcores-talks/2023-06-07-02/",
               "title": "2023-06-07 #2",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": "02"
+              "sequence_label": "02",
+              "anchor": "2023-06-07-02"
             }
           ]
         },
@@ -2321,7 +2500,8 @@
               "path": "/gcores-talks/2023-06-05/",
               "title": "2023-06-05",
               "topic": "🕺宅宅也能帅",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-06-05"
             }
           ]
         },
@@ -2334,7 +2514,8 @@
               "path": "/gcores-talks/2023-06-03/",
               "title": "2023-06-03",
               "topic": "🎦观影杂感",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-06-03"
             }
           ]
         },
@@ -2347,7 +2528,8 @@
               "path": "/gcores-talks/2023-06-01/",
               "title": "2023-06-01",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-06-01"
             }
           ]
         },
@@ -2360,7 +2542,8 @@
               "path": "/gcores-talks/2023-05-30/",
               "title": "2023-05-30",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-05-30"
             }
           ]
         },
@@ -2373,7 +2556,8 @@
               "path": "/gcores-talks/2023-05-24/",
               "title": "2023-05-24",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-05-24"
             }
           ]
         },
@@ -2386,7 +2570,8 @@
               "path": "/gcores-talks/2023-05-21/",
               "title": "2023-05-21",
               "topic": "🍿️追剧狂人",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-05-21"
             }
           ]
         },
@@ -2399,7 +2584,8 @@
               "path": "/gcores-talks/2023-05-18/",
               "title": "2023-05-18",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-05-18"
             }
           ]
         },
@@ -2412,7 +2598,8 @@
               "path": "/gcores-talks/2023-05-13/",
               "title": "2023-05-13",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-05-13"
             }
           ]
         },
@@ -2425,13 +2612,15 @@
               "path": "/gcores-talks/2023-05-06-01/",
               "title": "2023-05-06 #1",
               "topic": "🥘机组美食城",
-              "sequence_label": "01"
+              "sequence_label": "01",
+              "anchor": "2023-05-06-01"
             },
             {
               "path": "/gcores-talks/2023-05-06-02/",
               "title": "2023-05-06 #2",
               "topic": "🔖这段太精彩了",
-              "sequence_label": "02"
+              "sequence_label": "02",
+              "anchor": "2023-05-06-02"
             }
           ]
         },
@@ -2444,7 +2633,8 @@
               "path": "/gcores-talks/2023-05-05/",
               "title": "2023-05-05",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-05-05"
             }
           ]
         },
@@ -2457,7 +2647,8 @@
               "path": "/gcores-talks/2023-04-23/",
               "title": "2023-04-23",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-04-23"
             }
           ]
         },
@@ -2470,7 +2661,8 @@
               "path": "/gcores-talks/2023-04-20/",
               "title": "2023-04-20",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-04-20"
             }
           ]
         },
@@ -2483,7 +2675,8 @@
               "path": "/gcores-talks/2023-04-14/",
               "title": "2023-04-14",
               "topic": "🎮关于这个游戏的感受",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-04-14"
             }
           ]
         },
@@ -2496,7 +2689,8 @@
               "path": "/gcores-talks/2023-04-12/",
               "title": "2023-04-12",
               "topic": "🧩碎片故事",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-04-12"
             }
           ]
         },
@@ -2509,7 +2703,8 @@
               "path": "/gcores-talks/2023-03-27/",
               "title": "2023-03-27",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-03-27"
             }
           ]
         },
@@ -2522,7 +2717,8 @@
               "path": "/gcores-talks/2023-03-19/",
               "title": "2023-03-19",
               "topic": "🧩碎片故事",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-03-19"
             }
           ]
         },
@@ -2535,7 +2731,8 @@
               "path": "/gcores-talks/2023-02-07/",
               "title": "2023-02-07",
               "topic": "🎮关于这个游戏的感受",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-02-07"
             }
           ]
         },
@@ -2548,7 +2745,8 @@
               "path": "/gcores-talks/2023-01-20/",
               "title": "2023-01-20",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-01-20"
             }
           ]
         },
@@ -2561,19 +2759,22 @@
               "path": "/gcores-talks/2023-01-15-01/",
               "title": "2023-01-15 #1",
               "topic": "🔧手艺人",
-              "sequence_label": "01"
+              "sequence_label": "01",
+              "anchor": "2023-01-15-01"
             },
             {
               "path": "/gcores-talks/2023-01-15-02/",
               "title": "2023-01-15 #2",
               "topic": "🧩一枚生活碎片",
-              "sequence_label": "02"
+              "sequence_label": "02",
+              "anchor": "2023-01-15-02"
             },
             {
               "path": "/gcores-talks/2023-01-15-03/",
               "title": "2023-01-15 #3",
               "topic": "🍙动画打卡",
-              "sequence_label": "03"
+              "sequence_label": "03",
+              "anchor": "2023-01-15-03"
             }
           ]
         },
@@ -2586,7 +2787,8 @@
               "path": "/gcores-talks/2023-01-04/",
               "title": "2023-01-04",
               "topic": "🧚俗世奇人",
-              "sequence_label": ""
+              "sequence_label": "",
+              "anchor": "2023-01-04"
             }
           ]
         }

--- a/scripts/split-daily-logs.mjs
+++ b/scripts/split-daily-logs.mjs
@@ -291,6 +291,10 @@ async function writeDailyIndex(data) {
   await writeFile(path.join(dataDir, "daily-index.json"), JSON.stringify(data, null, 2));
 }
 
+function anchorFromPath(urlPath) {
+  return String(urlPath).split("/").filter(Boolean).pop() ?? "";
+}
+
 function buildDailyToc(entries, { groupBy }) {
   const dateCounts = entries.reduce((memo, entry) => {
     memo.set(entry.date, (memo.get(entry.date) ?? 0) + 1);
@@ -324,6 +328,7 @@ function buildDailyToc(entries, { groupBy }) {
 
     groupRecord.dateMap.get(entry.date).entries.push({
       path: entry.path,
+      anchor: anchorFromPath(entry.path),
       title: entry.title,
       topic: entry.topic ?? "",
       sequence_label: duplicateCount > 1 ? pad(entry.sequence ?? 1) : "",

--- a/themes/cone-scroll/static/css/style.css
+++ b/themes/cone-scroll/static/css/style.css
@@ -447,8 +447,46 @@ main {
   display: block;
 }
 
+.daily-outline-row {
+  display: inline-flex;
+  align-items: baseline;
+  max-width: 100%;
+  gap: 0.28rem;
+}
+
 .daily-outline-entry {
+  min-width: 0;
   overflow-wrap: anywhere;
+}
+
+.daily-outline-anchor {
+  min-width: 0;
+}
+
+.daily-outline-open {
+  flex: 0 0 auto;
+  color: var(--muted);
+  text-decoration: none;
+  opacity: 0;
+  transform: translateX(-0.2rem);
+}
+
+.daily-outline-open:visited {
+  color: var(--muted);
+}
+
+.daily-outline li:hover > .daily-outline-row .daily-outline-open,
+.daily-outline li:focus-within > .daily-outline-row .daily-outline-open,
+.daily-outline-row:hover .daily-outline-open,
+.daily-outline-row:focus-within .daily-outline-open {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.daily-outline-open:hover,
+.daily-outline-open:focus {
+  color: var(--fg);
+  text-decoration: underline;
 }
 
 .daily-outline-seq,
@@ -487,6 +525,7 @@ main {
   margin: 0 0 2rem;
   padding: 0 0 2rem;
   border-bottom: 1px solid var(--border);
+  scroll-margin-top: 1.75rem;
 }
 
 .daily-entry-card:last-child {
@@ -662,7 +701,8 @@ footer nav + p {
 
 @media (prefers-reduced-motion: no-preference) {
   .page-outline-nav,
-  .page-outline-toggle {
+  .page-outline-toggle,
+  .daily-outline-open {
     transition: opacity 0.18s ease, transform 0.18s ease, color 0.18s ease;
   }
 }
@@ -671,8 +711,20 @@ footer nav + p {
   .page-shell.has-outline,
   .page-outline,
   .page-outline-nav,
-  .page-outline-toggle {
+  .page-outline-toggle,
+  .daily-outline-open {
     transition: none;
+  }
+
+  .daily-outline-open {
+    transform: none;
+  }
+}
+
+@media (hover: none) {
+  .daily-outline-open {
+    opacity: 1;
+    transform: none;
   }
 }
 
@@ -1452,6 +1504,11 @@ address.post-meta {
 
   .daily-outline {
     margin: 0.65rem 0 1.4rem;
+  }
+
+  .daily-outline-open {
+    opacity: 1;
+    transform: none;
   }
 
   .daily-entry-card {

--- a/themes/cone-scroll/static/js/script.js
+++ b/themes/cone-scroll/static/js/script.js
@@ -281,73 +281,162 @@
       const status = archive.querySelector("[data-infinite-status]");
       const sentinel = archive.querySelector("[data-infinite-sentinel]");
 
-      if (!list || !nextLink || !status) {
+      if (!list) {
         return;
       }
 
       archive.setAttribute("data-infinite-bound", "true");
       let loading = false;
-      let finished = !nextLink.getAttribute("href");
+      let loadingPromise;
+      let finished = !nextLink || !nextLink.getAttribute("href");
       let lastAutoLoadY = -Infinity;
+
+      function setStatus(message) {
+        if (status) {
+          status.textContent = message;
+        }
+      }
 
       async function loadNext(event) {
         if (event) {
           event.preventDefault();
         }
 
-        const nextUrl = nextLink.getAttribute("href");
+        if (loading) {
+          return loadingPromise;
+        }
+
+        const nextUrl = nextLink ? nextLink.getAttribute("href") : "";
         if (loading || finished || !nextUrl) {
-          return;
+          return false;
         }
 
         loading = true;
         archive.setAttribute("aria-busy", "true");
-        nextLink.textContent = "加载中";
-        status.textContent = "正在加载下一页";
+        if (nextLink) {
+          nextLink.textContent = "加载中";
+        }
+        setStatus("正在加载下一页");
+
+        loadingPromise = (async function () {
+          try {
+            const response = await fetch(nextUrl, {
+              headers: {
+                "X-Requested-With": "daily-archive",
+              },
+            });
+
+            if (!response.ok) {
+              throw new Error("Failed to load next archive page");
+            }
+
+            const html = await response.text();
+            const doc = new DOMParser().parseFromString(html, "text/html");
+            const incomingList = doc.querySelector("[data-infinite-list]");
+            const incomingItems = incomingList ? Array.from(incomingList.children) : [];
+            const incomingNext = doc.querySelector("[data-infinite-next]");
+
+            incomingItems.forEach((item) => {
+              list.appendChild(document.importNode(item, true));
+            });
+
+            if (incomingNext && incomingNext.getAttribute("href")) {
+              nextLink.setAttribute("href", incomingNext.getAttribute("href"));
+              nextLink.textContent = "继续加载";
+              setStatus(`已加载 ${incomingItems.length} 则`);
+            } else if (nextLink) {
+              finished = true;
+              nextLink.removeAttribute("href");
+              nextLink.hidden = true;
+              setStatus("已经到底");
+            }
+
+            initInteractiveControls();
+            return incomingItems.length > 0;
+          } catch (error) {
+            setStatus("加载失败，可以使用分页链接继续浏览");
+            if (nextLink) {
+              nextLink.textContent = "打开下一页";
+            }
+            return false;
+          } finally {
+            loading = false;
+            loadingPromise = undefined;
+            archive.removeAttribute("aria-busy");
+          }
+        })();
+
+        return loadingPromise;
+      }
+
+      function getAnchorTarget(anchor) {
+        const target = document.getElementById(anchor);
+        return target && archive.contains(target) ? target : null;
+      }
+
+      function updateHash(link) {
+        if (!link || !history.pushState) {
+          return;
+        }
 
         try {
-          const response = await fetch(nextUrl, {
-            headers: {
-              "X-Requested-With": "daily-archive",
-            },
-          });
-
-          if (!response.ok) {
-            throw new Error("Failed to load next archive page");
-          }
-
-          const html = await response.text();
-          const doc = new DOMParser().parseFromString(html, "text/html");
-          const incomingList = doc.querySelector("[data-infinite-list]");
-          const incomingItems = incomingList ? Array.from(incomingList.children) : [];
-          const incomingNext = doc.querySelector("[data-infinite-next]");
-
-          incomingItems.forEach((item) => {
-            list.appendChild(document.importNode(item, true));
-          });
-
-          if (incomingNext && incomingNext.getAttribute("href")) {
-            nextLink.setAttribute("href", incomingNext.getAttribute("href"));
-            nextLink.textContent = "继续加载";
-            status.textContent = `已加载 ${incomingItems.length} 则`;
-          } else {
-            finished = true;
-            nextLink.removeAttribute("href");
-            nextLink.hidden = true;
-            status.textContent = "已经到底";
-          }
-
-          initInteractiveControls();
+          history.pushState(null, "", link.getAttribute("href"));
         } catch (error) {
-          status.textContent = "加载失败，可以使用分页链接继续浏览";
-          nextLink.textContent = "打开下一页";
-        } finally {
-          loading = false;
-          archive.removeAttribute("aria-busy");
+          return;
         }
       }
 
-      nextLink.addEventListener("click", loadNext);
+      function scrollToAnchorTarget(anchor, link) {
+        const target = getAnchorTarget(anchor);
+        if (!target) {
+          return false;
+        }
+
+        updateHash(link);
+        const prefersReducedMotion =
+          window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+        target.scrollIntoView({
+          block: "start",
+          behavior: prefersReducedMotion ? "auto" : "smooth",
+        });
+        if (typeof target.focus === "function") {
+          target.focus({ preventScroll: true });
+        }
+        setStatus("已定位到目标日期");
+        return true;
+      }
+
+      async function resolveDailyAnchor(anchor, link) {
+        if (!anchor || scrollToAnchorTarget(anchor, link)) {
+          return;
+        }
+
+        setStatus("正在加载目标日期");
+        while (!finished) {
+          const loaded = await loadNext();
+          if (!loaded || scrollToAnchorTarget(anchor, link)) {
+            return;
+          }
+        }
+
+        setStatus("未找到目标日期，可以使用单日链接打开");
+      }
+
+      archive.querySelectorAll("[data-daily-anchor-link]").forEach((link) => {
+        link.addEventListener("click", (event) => {
+          event.preventDefault();
+          const anchor = link.getAttribute("data-daily-anchor") || link.hash.slice(1);
+          resolveDailyAnchor(anchor, link);
+        });
+      });
+
+      if (window.location.hash) {
+        resolveDailyAnchor(decodeURIComponent(window.location.hash.slice(1)));
+      }
+
+      if (nextLink) {
+        nextLink.addEventListener("click", loadNext);
+      }
 
       if (sentinel && "IntersectionObserver" in window) {
         const observer = new IntersectionObserver((entries) => {

--- a/themes/cone-scroll/templates/daily-archive.html
+++ b/themes/cone-scroll/templates/daily-archive.html
@@ -65,15 +65,21 @@
                         <ol class="daily-outline-sequences">
                           {% for item in date_group.entries %}
                             <li>
-                              <a class="daily-outline-entry" href="{{ item.path | safe }}">
-                                <span class="daily-outline-seq">{{ item.sequence_label }}</span>{% if item.topic %}<span>{{ item.topic }}</span>{% else %}<span>{{ item.title }}</span>{% endif %}
-                              </a>
+                              <span class="daily-outline-row">
+                                <a class="daily-outline-entry daily-outline-anchor" href="#{{ item.anchor }}" data-daily-anchor-link data-daily-anchor="{{ item.anchor }}">
+                                  <span class="daily-outline-seq">{{ item.sequence_label }}</span>{% if item.topic %}<span>{{ item.topic }}</span>{% else %}<span>{{ item.title }}</span>{% endif %}
+                                </a>
+                                <a class="daily-outline-open" href="{{ item.path | safe }}" aria-label="打开 {{ item.title }} 的单独页面">+</a>
+                              </span>
                             </li>
                           {% endfor %}
                         </ol>
                       {% else %}
                         {% for item in date_group.entries %}
-                          <a href="{{ item.path | safe }}">{{ date_group.label }}</a>
+                          <span class="daily-outline-row">
+                            <a class="daily-outline-anchor" href="#{{ item.anchor }}" data-daily-anchor-link data-daily-anchor="{{ item.anchor }}">{{ date_group.label }}</a>
+                            <a class="daily-outline-open" href="{{ item.path | safe }}" aria-label="打开 {{ item.title }} 的单独页面">+</a>
+                          </span>
                           {% if item.topic %}<span class="daily-outline-topic">{{ item.topic }}</span>{% endif %}
                         {% endfor %}
                       {% endif %}
@@ -90,7 +96,7 @@
     <section class="daily-feed" aria-label="{{ section.title }}">
       <div class="daily-entry-list" data-infinite-list>
         {% for entry in entries %}
-          <article class="daily-entry-card" id="{{ entry.slug }}" data-daily-entry-card>
+          <article class="daily-entry-card" id="{{ entry.slug }}" data-daily-entry-card tabindex="-1">
             <header class="daily-entry-card-head">
               <h2><a href="{{ entry.permalink | safe }}">{{ entry.title }}</a></h2>
               <p class="daily-entry-meta">


### PR DESCRIPTION
## Summary

- Implement Version D daily archive TOC behavior: date links scroll within the aggregate archive.
- Add inline `+` links for opening standalone daily pages, including same-day sequence rows.
- Extend infinite loading so TOC clicks can resolve dates that are not loaded yet.

## Validation

- `git diff --check`
- `node --check themes/cone-scroll/static/js/script.js`
- `nix-shell --run 'zola build'`
- Playwright viewport and interaction assertions for `/gcores-talks/`, `/diary/2020/`, and `/diary/2026/` at:
  - `393x852`
  - `1440x900`
  - `2560x1440`
- Computer Use inspection in Zen at `http://127.0.0.1:1117/gcores-talks/`

## Notes

The split source files are not present in this worktree, so `data/daily-toc.json` was updated mechanically from existing `path` values. `scripts/split-daily-logs.mjs` now emits the same `anchor` field for future full regenerations.
